### PR TITLE
[Meta-bot] Update service versions + PHP extensions

### DIFF
--- a/resources/image/registry.json
+++ b/resources/image/registry.json
@@ -35,7 +35,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "113",
@@ -58,7 +59,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "95",
@@ -81,7 +83,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "91",
@@ -104,7 +107,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "86",
@@ -127,7 +131,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "84",
@@ -150,7 +155,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "83",
@@ -173,7 +179,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "81",
@@ -196,7 +203,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "80",
@@ -219,7 +227,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "73",
@@ -242,7 +251,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ],
     "versions-dedicated-gen-3": {
@@ -292,7 +302,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "25.3",
@@ -319,7 +330,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "24.3",
@@ -346,7 +358,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "23.8",
@@ -373,7 +386,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ]
   },
@@ -432,7 +446,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "7.0",
@@ -455,7 +470,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "6.0",
@@ -478,7 +494,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "5.0",
@@ -501,7 +518,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "3.1",
@@ -524,7 +542,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "2.2",
@@ -547,7 +566,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "2.1",
@@ -570,7 +590,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "2.0",
@@ -593,7 +614,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       }
     ]
   },
@@ -628,7 +650,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "7.10",
@@ -652,7 +675,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "7.9",
@@ -676,7 +700,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "7.7",
@@ -700,7 +725,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "7.6",
@@ -724,7 +750,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "7.5",
@@ -748,7 +775,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "7.2",
@@ -772,7 +800,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "6.8",
@@ -796,7 +825,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "6.5",
@@ -820,7 +850,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "5.4",
@@ -844,7 +875,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "5.2",
@@ -868,7 +900,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "2.4",
@@ -892,7 +925,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "1.7",
@@ -910,7 +944,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "1.4",
@@ -928,7 +963,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "0.90",
@@ -946,7 +982,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ],
     "versions-dedicated-gen-2": {
@@ -1039,7 +1076,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.15",
@@ -1062,7 +1100,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.14",
@@ -1085,7 +1124,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.13",
@@ -1108,7 +1148,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.12",
@@ -1131,7 +1172,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.11",
@@ -1154,7 +1196,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.10",
@@ -1177,7 +1220,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.9",
@@ -1200,7 +1244,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       }
     ]
   },
@@ -1260,7 +1305,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.24",
@@ -1283,7 +1329,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.23",
@@ -1306,7 +1353,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.22",
@@ -1329,7 +1377,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.21",
@@ -1352,7 +1401,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.20",
@@ -1375,7 +1425,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.19",
@@ -1398,7 +1449,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.18",
@@ -1421,7 +1473,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.17",
@@ -1444,7 +1497,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.16",
@@ -1467,7 +1521,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.15",
@@ -1490,7 +1545,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.14",
@@ -1513,7 +1569,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.13",
@@ -1536,7 +1593,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.12",
@@ -1559,7 +1617,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.11",
@@ -1582,7 +1641,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.10",
@@ -1605,7 +1665,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.9",
@@ -1628,7 +1689,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "1.8",
@@ -1651,7 +1713,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       }
     ]
   },
@@ -1691,7 +1754,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "2.3",
@@ -1714,7 +1778,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "2.2",
@@ -1732,7 +1797,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "2.1",
@@ -1750,7 +1816,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "2.0",
@@ -1768,7 +1835,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "1.8",
@@ -1791,7 +1859,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "1.7",
@@ -1814,7 +1883,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "1.3",
@@ -1838,7 +1908,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "1.2",
@@ -1856,7 +1927,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ]
   },
@@ -1896,7 +1968,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": false
       }
     ]
   },
@@ -1945,7 +2018,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "19",
@@ -1968,7 +2042,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "18",
@@ -1991,7 +2066,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "17 (LTS)",
@@ -2014,7 +2090,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "14",
@@ -2037,7 +2114,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "13",
@@ -2060,7 +2138,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "12",
@@ -2083,7 +2162,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "11",
@@ -2106,7 +2186,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "8",
@@ -2129,7 +2210,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       }
     ],
     "versions-dedicated-gen-2": {
@@ -2181,7 +2263,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.6",
@@ -2204,7 +2287,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.4",
@@ -2227,7 +2311,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.2",
@@ -2250,7 +2335,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "2.7",
@@ -2268,7 +2354,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "2.6",
@@ -2286,7 +2373,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "2.5",
@@ -2304,7 +2392,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "2.4",
@@ -2322,7 +2411,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "2.3",
@@ -2340,7 +2430,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "2.2",
@@ -2358,7 +2449,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "2.1",
@@ -2376,7 +2468,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ]
   },
@@ -2418,7 +2511,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "11.4 (LTS)",
@@ -2443,7 +2537,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "11.3",
@@ -2468,7 +2563,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "11.2",
@@ -2493,7 +2589,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "11.0",
@@ -2518,7 +2615,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "10.11 (LTS)",
@@ -2543,7 +2641,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "10.6 (LTS)",
@@ -2568,7 +2667,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "10.5",
@@ -2593,7 +2693,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "10.4",
@@ -2618,7 +2719,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "10.3",
@@ -2643,7 +2745,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "10.2",
@@ -2668,7 +2771,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "10.1",
@@ -2693,7 +2797,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "10.0",
@@ -2718,7 +2823,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "5.5",
@@ -2743,7 +2849,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ],
     "versions-dedicated-gen-2": {
@@ -2876,7 +2983,8 @@
           "is_persistent": null,
           "default_container_profile": "BALANCED",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "1.5",
@@ -2900,7 +3008,8 @@
           "is_persistent": null,
           "default_container_profile": "BALANCED",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "1.4",
@@ -2924,7 +3033,8 @@
           "is_persistent": null,
           "default_container_profile": "BALANCED",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ],
     "versions-dedicated-gen-2": {
@@ -2976,7 +3086,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.6",
@@ -3005,7 +3116,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.4",
@@ -3034,7 +3146,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.2",
@@ -3063,7 +3176,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.0",
@@ -3092,7 +3206,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ]
   },
@@ -3134,7 +3249,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "6.0",
@@ -3158,7 +3274,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "5.0",
@@ -3182,7 +3299,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "4.4",
@@ -3206,7 +3324,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "4.2",
@@ -3230,7 +3349,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "4.0",
@@ -3254,7 +3374,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ],
     "versions-dedicated-gen-2": {
@@ -3340,7 +3461,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "22 (LTS)",
@@ -3363,7 +3485,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "20 (LTS)",
@@ -3386,7 +3509,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "18",
@@ -3409,7 +3533,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "16",
@@ -3432,7 +3557,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "8.9",
@@ -3455,7 +3581,8 @@
           "is_persistent": null,
           "default_container_profile": null,
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "6.10",
@@ -3478,7 +3605,8 @@
           "is_persistent": null,
           "default_container_profile": null,
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "6.9",
@@ -3501,7 +3629,8 @@
           "is_persistent": null,
           "default_container_profile": null,
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "6.8",
@@ -3524,7 +3653,8 @@
           "is_persistent": null,
           "default_container_profile": null,
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "6.6",
@@ -3547,7 +3677,8 @@
           "is_persistent": null,
           "default_container_profile": null,
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "6.3",
@@ -3570,7 +3701,8 @@
           "is_persistent": null,
           "default_container_profile": null,
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "6.2",
@@ -3593,7 +3725,8 @@
           "is_persistent": null,
           "default_container_profile": null,
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "4.7",
@@ -3616,7 +3749,8 @@
           "is_persistent": null,
           "default_container_profile": null,
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "4.6",
@@ -3639,7 +3773,8 @@
           "is_persistent": null,
           "default_container_profile": null,
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "4.5",
@@ -3662,7 +3797,8 @@
           "is_persistent": null,
           "default_container_profile": null,
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "4.4",
@@ -3685,7 +3821,8 @@
           "is_persistent": null,
           "default_container_profile": null,
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "4.3",
@@ -3708,7 +3845,8 @@
           "is_persistent": null,
           "default_container_profile": null,
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "4.2",
@@ -3731,7 +3869,8 @@
           "is_persistent": null,
           "default_container_profile": null,
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "0.12",
@@ -3754,7 +3893,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       }
     ],
     "versions-dedicated-gen-2": {
@@ -3810,7 +3950,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "2",
@@ -3834,7 +3975,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "1.2",
@@ -3858,7 +4000,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "1.1",
@@ -3882,7 +4025,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "1",
@@ -3906,7 +4050,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ],
     "versions-dedicated-gen-2": {
@@ -3960,7 +4105,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "8.0",
@@ -3978,7 +4124,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "5.7",
@@ -3996,7 +4143,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ]
   },
@@ -4078,7 +4226,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "8.4",
@@ -4105,7 +4254,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "8.3",
@@ -4132,7 +4282,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "8.2",
@@ -4159,7 +4310,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "8.1",
@@ -4186,7 +4338,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "8.0",
@@ -4213,7 +4366,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "7.4",
@@ -4240,7 +4394,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "7.3",
@@ -4267,7 +4422,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "7.2",
@@ -4294,7 +4450,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "7.1",
@@ -4321,7 +4478,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "7.0",
@@ -4348,7 +4506,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "5.6",
@@ -4375,7 +4534,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "5.5",
@@ -4402,7 +4562,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "5.4",
@@ -4429,7 +4590,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       }
     ]
   },
@@ -4480,7 +4642,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "17",
@@ -4506,7 +4669,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "16",
@@ -4532,7 +4696,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "15",
@@ -4558,7 +4723,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "14",
@@ -4584,7 +4750,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "13",
@@ -4610,7 +4777,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "12",
@@ -4636,7 +4804,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "11",
@@ -4662,7 +4831,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "10",
@@ -4688,7 +4858,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "9.6",
@@ -4714,7 +4885,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "9.5",
@@ -4732,7 +4904,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "9.3",
@@ -4758,7 +4931,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ],
     "versions-dedicated-gen-2": {
@@ -4838,7 +5012,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "3.12",
@@ -4861,7 +5036,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "3.11",
@@ -4884,7 +5060,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "3.10",
@@ -4907,7 +5084,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "3.9",
@@ -4930,7 +5108,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "3.8",
@@ -4953,7 +5132,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "3.7",
@@ -4976,7 +5156,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "3.6",
@@ -4999,7 +5180,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "3.5",
@@ -5022,7 +5204,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "2.7",
@@ -5045,7 +5228,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       }
     ]
   },
@@ -5089,7 +5273,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "4.0",
@@ -5116,7 +5301,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.13",
@@ -5143,7 +5329,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.12",
@@ -5170,7 +5357,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.11",
@@ -5197,7 +5385,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.10",
@@ -5224,7 +5413,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.9",
@@ -5251,7 +5441,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.8",
@@ -5278,7 +5469,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.7",
@@ -5305,7 +5497,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.6",
@@ -5332,7 +5525,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.5",
@@ -5359,7 +5553,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ],
     "versions-dedicated-gen-2": {
@@ -5427,7 +5622,8 @@
           "is_persistent": null,
           "default_container_profile": "BALANCED",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "7.2",
@@ -5452,7 +5648,8 @@
           "is_persistent": null,
           "default_container_profile": "BALANCED",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "7.0",
@@ -5477,7 +5674,8 @@
           "is_persistent": null,
           "default_container_profile": "BALANCED",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "6.2",
@@ -5502,7 +5700,8 @@
           "is_persistent": null,
           "default_container_profile": "BALANCED",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "6.0",
@@ -5527,7 +5726,8 @@
           "is_persistent": null,
           "default_container_profile": "BALANCED",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "5.0",
@@ -5552,7 +5752,8 @@
           "is_persistent": null,
           "default_container_profile": "BALANCED",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "4.0",
@@ -5577,7 +5778,8 @@
           "is_persistent": null,
           "default_container_profile": "BALANCED",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.2",
@@ -5602,7 +5804,8 @@
           "is_persistent": null,
           "default_container_profile": "BALANCED",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.0",
@@ -5627,7 +5830,8 @@
           "is_persistent": null,
           "default_container_profile": "BALANCED",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "2.8",
@@ -5645,7 +5849,8 @@
           "is_persistent": null,
           "default_container_profile": "BALANCED",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ],
     "versions-dedicated-gen-2": {
@@ -5741,7 +5946,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "3.3",
@@ -5764,7 +5970,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "3.2",
@@ -5787,7 +5994,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "3.1",
@@ -5810,7 +6018,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "3.0",
@@ -5833,7 +6042,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "2.7",
@@ -5856,7 +6066,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "2.6",
@@ -5879,7 +6090,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "2.5",
@@ -5902,7 +6114,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "2.4",
@@ -5925,7 +6138,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       },
       {
         "name": "2.3",
@@ -5948,7 +6162,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": true
       }
     ],
     "versions-dedicated-gen-3": {
@@ -6015,7 +6230,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_CPU",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": true
       }
     ]
   },
@@ -6056,7 +6272,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "9.7",
@@ -6080,7 +6297,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "9.6",
@@ -6104,7 +6322,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "9.4",
@@ -6128,7 +6347,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "9.2",
@@ -6152,7 +6372,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "9.1",
@@ -6176,7 +6397,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "9.0",
@@ -6194,7 +6416,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "8.11",
@@ -6218,7 +6441,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "8.6",
@@ -6242,7 +6466,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "8.4",
@@ -6266,7 +6491,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "8.0",
@@ -6290,7 +6516,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "7.7",
@@ -6314,7 +6541,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "7.6",
@@ -6338,7 +6566,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "6.6",
@@ -6362,7 +6591,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "6.3",
@@ -6386,7 +6616,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "4.10",
@@ -6410,7 +6641,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "3.6",
@@ -6434,7 +6666,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ],
     "versions-dedicated-gen-2": {
@@ -6509,7 +6742,8 @@
           "is_persistent": null,
           "default_container_profile": "BALANCED",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "8.0",
@@ -6534,7 +6768,8 @@
           "is_persistent": null,
           "default_container_profile": "BALANCED",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ],
     "versions-dedicated-gen-2": {
@@ -6588,7 +6823,8 @@
           "is_persistent": false,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "7.3",
@@ -6616,7 +6852,8 @@
           "is_persistent": false,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "7.2",
@@ -6644,7 +6881,8 @@
           "is_persistent": false,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "7.1",
@@ -6672,7 +6910,8 @@
           "is_persistent": false,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "6.3 (LTS)",
@@ -6700,7 +6939,8 @@
           "is_persistent": false,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "6.0 (LTS)",
@@ -6728,7 +6968,8 @@
           "is_persistent": false,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": true
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "5.2",
@@ -6755,7 +6996,8 @@
           "is_persistent": false,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "5.1",
@@ -6782,7 +7024,8 @@
           "is_persistent": false,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ]
   },
@@ -6840,7 +7083,8 @@
         "is_end_of_active_support": false,
         "is_end_of_life": false,
         "is_long_time_support": false,
-        "manifest": null
+        "manifest": null,
+        "is_runtime": false
       },
       {
         "name": "2",
@@ -6858,7 +7102,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ]
   },
@@ -6886,7 +7131,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "7.17",
@@ -6910,7 +7156,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ]
   },
@@ -6932,7 +7179,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "1.8",
@@ -6950,7 +7198,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       },
       {
         "name": "1.6",
@@ -6968,7 +7217,8 @@
           "is_persistent": null,
           "default_container_profile": "HIGH_MEMORY",
           "supports_horizontal_scaling": null
-        }
+        },
+        "is_runtime": false
       }
     ]
   }


### PR DESCRIPTION
This PR is generated from Meta Version updater cached data.

- Ingest stores GitLab + upstream metadata (endoflife.date or custom) into each service.
- Export reads cache once and updates registry + php_extensions grid.

Files updated:
- `resources/image/registry.json`
- `resources/extension/php_extensions.yaml`