### PR TITLE
solve empty security.BearerAuth

### DIFF
--- a/resources/openapi/openapispec-upsun-sdks.json
+++ b/resources/openapi/openapispec-upsun-sdks.json
@@ -28,7 +28,7 @@
     ],
     "security": [
         {
-            "BearerAuth": {}
+            "BearerAuth": []
         }
     ],
     "tags": [

--- a/scripts/pre-processing/preprocess-schema.php
+++ b/scripts/pre-processing/preprocess-schema.php
@@ -497,18 +497,22 @@ class OpenApiPreprocessor
     }
 
     // Helper function: convert empty arrays to stdClass to preserve object types
-    private function forceEmptyObjects($data)
+    private function forceEmptyObjects($data, array $path = [])
     {
         if (is_array($data)) {
-            if (empty($data)) {
+            $isSecurityNode = !empty($path) && end($path) === 'BearerAuth';
+            if (empty($data) && !$isSecurityNode) {
                 return new stdClass();
             }
+            if (empty($data) && $isSecurityNode) {
+                return [];
+            } 
 
             $result = [];
             $isAssociative = array_keys($data) !== range(0, count($data) - 1);
 
             foreach ($data as $key => $value) {
-                $result[$key] = $this->forceEmptyObjects($value);
+                $result[$key] = $this->forceEmptyObjects($value, array_merge($path, [$key]));
             }
 
             return $isAssociative && empty($result) ? new stdClass() : $result;


### PR DESCRIPTION
to avoid having this in the openapispec-upsun SDK oriented 
```
"security": [
         {
           "BearerAuth": {}
         }
     ],
```
That would result in an empty OAuth mechanism and so, no auto-authentication mecanism
