### PR TITLE
Add etag cache

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -35,6 +35,10 @@ GITHUB_BASE_PATH=resources
 # Optional: GitHub Personal Access Token for private repositories (not needed for public repos)
 GITHUB_TOKEN=
 
+# Cache Configuration
+# TTL (Time To Live) in seconds for HTTP cache headers (default: 300 = 5 minutes)
+CACHE_TTL=300
+
 # Local Resources Path (when RESOURCES_MODE=local)
 # Relative to backend folder
 LOCAL_RESOURCES_PATH=../../../resources

--- a/backend/doc/CONDITIONAL_FETCH_OPTIMIZATION.md
+++ b/backend/doc/CONDITIONAL_FETCH_OPTIMIZATION.md
@@ -1,0 +1,174 @@
+# Conditional Fetch Optimization
+
+## Problem
+Previously, `getGithubResourceWithMetadata` always downloaded and parsed the full file from GitHub *before* the application could decide to return a 304 Not Modified response. This meant that even when a client had a valid cached version (sent `If-None-Match`), the server still:
+1. Fetched the entire file from GitHub
+2. Parsed the JSON/YAML content
+3. Only then checked if the client cache was valid
+4. Returned 304 (but the expensive work was already done)
+
+This was especially costly in GitHub mode where network latency and API rate limits are concerns.
+
+## Solution
+The optimization implements **upstream conditional requests** that propagate client cache validation headers to GitHub, allowing the entire fetch/parse cycle to be skipped when content hasn't changed.
+
+### How it Works
+
+#### 1. Extract Conditional Headers
+```typescript
+const conditionalHeaders = extractConditionalHeaders(req);
+// Returns: { ifNoneMatch: "etag-value", ifModifiedSince: "date" }
+```
+
+#### 2. Pass Headers to GitHub
+```typescript
+const { data, metadata, notModified } = await resourceManager.getResourceWithMetadata(
+  'image/registry.json', 
+  conditionalHeaders
+);
+```
+
+#### 3. GitHub Returns 304 (if unchanged)
+When GitHub's content matches the client's cached ETag or hasn't been modified since the specified date, GitHub returns `304 Not Modified` with no body.
+
+#### 4. Short-Circuit Response
+```typescript
+if (notModified) {
+  return sendNotModified(res, metadata);  // No parsing, immediate 304
+}
+// Only reached if content changed - process data normally
+```
+
+### Request Flow
+
+**Before (always fetches):**
+```
+Client → API: GET /images (If-None-Match: "abc123")
+API → GitHub: GET registry.json (no conditional headers)
+GitHub → API: 200 OK + 300KB JSON body
+API: Parse JSON (expensive)
+API: Check client ETag matches
+API → Client: 304 Not Modified (but work already done!)
+```
+
+**After (conditional fetch):**
+```
+Client → API: GET /images (If-None-Match: "abc123")
+API → GitHub: GET registry.json (If-None-Match: "abc123")
+GitHub → API: 304 Not Modified (no body!)
+API → Client: 304 Not Modified (skipped parsing entirely)
+```
+
+## Benefits
+
+1. **Reduced Bandwidth**: No file download when content unchanged
+2. **Faster Responses**: No JSON/YAML parsing overhead
+3. **Lower GitHub API Usage**: Conditional requests don't consume as much rate limit
+4. **Better Resource Utilization**: Server CPU time saved on parsing
+5. **Improved Scalability**: Can handle more concurrent clients with same resources
+
+## Implementation Details
+
+### New Types & Interfaces
+
+```typescript
+export interface ConditionalHeaders {
+  ifNoneMatch?: string;
+  ifModifiedSince?: string;
+}
+
+export interface ResourceWithMetadata<T = any> {
+  data: T;
+  metadata: ResourceMetadata;
+  notModified?: boolean; // true when upstream returns 304
+}
+```
+
+### Modified Functions
+
+#### ResourceManager
+- `getResourceWithMetadata(filePath, conditionalHeaders?)` - Added optional conditional headers parameter
+- `getResourceRawWithMetadata(filePath, conditionalHeaders?)` - Added optional conditional headers parameter
+- `getGithubResourceWithMetadata(filePath, conditionalHeaders?)` - Now passes headers to GitHub and handles 304
+- `getGithubResourceRawWithMetadata(filePath, conditionalHeaders?)` - Same for raw content
+
+#### CacheManager
+- `extractConditionalHeaders(req)` - New helper to extract `If-None-Match`/`If-Modified-Since` from Express request
+
+### Updated Routes
+All routes using `getResourceWithMetadata` or `getResourceRawWithMetadata` were updated:
+- `/images` and `/images/:id`
+- `/extensions/php`, `/extensions/php/cloud`, `/extensions/php/cloud/:id`
+- `/regions` and `/regions/:id`
+- `/composable`
+- `/openapi-spec`
+- `/schema/upsun`, `/schema/image-registry`, `/schema/service-versions`, `/schema/runtime-versions`
+
+## Testing
+
+### Manual Test
+```bash
+# First request - gets full content with ETag
+curl -i http://localhost:3000/images
+
+# Note the ETag from response headers:
+# ETag: "1773391306186-305001"
+
+# Second request - uses If-None-Match
+curl -i -H 'If-None-Match: "1773391306186-305001"' http://localhost:3000/images
+
+# Should return:
+# HTTP/1.1 304 Not Modified
+# (no body)
+```
+
+### Logs to Monitor
+When GitHub mode is active, logs will show:
+```
+"GitHub returned 304 Not Modified - cache still valid"
+```
+
+## Configuration
+
+The optimization is **automatic** and works in both modes:
+
+- **Local mode** (`RESOURCES_MODE=local`): Checks local file stats, returns 304 if unchanged
+- **GitHub mode** (`RESOURCES_MODE=github`): Passes conditional headers to GitHub, returns 304 if GitHub returns 304
+
+No configuration changes needed - it's transparent to clients.
+
+## Performance Impact
+
+### Expected Improvements (GitHub mode)
+- **Cache hit latency**: ~200-500ms network roundtrip (vs 1000-2000ms fetch+parse)
+- **Bandwidth savings**: 100% on cache hits (no body transferred)
+- **CPU usage**: Eliminates JSON/YAML parsing on cache hits
+- **GitHub rate limit**: Conditional requests may have reduced impact on rate limits
+
+### Measurement
+Monitor these metrics:
+1. Response time for requests with `If-None-Match` header
+2. GitHub API calls per minute
+3. Server CPU utilization
+4. Ratio of 304 vs 200 responses
+
+## Backward Compatibility
+
+✅ **Fully backward compatible**
+- Clients without `If-None-Match` header still get 200 responses
+- Local mode continues to work as before
+- No breaking changes to API responses or behavior
+
+## Future Enhancements
+
+Potential improvements:
+1. **Client-side caching**: Include `Cache-Control: max-age=300` already set
+2. **ETag with content hash**: For even better cache validation
+3. **Stale-while-revalidate**: Return stale content while checking for updates in background
+4. **Metrics dashboard**: Track cache hit rates and performance gains
+
+## References
+
+- RFC 7232: HTTP/1.1 Conditional Requests
+- [GitHub ETag documentation](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#conditional-requests)
+- Repository memory: `/memories/repo/caching-etag.md`

--- a/backend/doc/CONDITIONAL_FETCH_OPTIMIZATION.md
+++ b/backend/doc/CONDITIONAL_FETCH_OPTIMIZATION.md
@@ -130,10 +130,10 @@ When GitHub mode is active, logs will show:
 
 ## Configuration
 
-The optimization is **automatic** and works in both modes:
+The optimization is **automatic** when using GitHub-backed resources:
 
-- **Local mode** (`RESOURCES_MODE=local`): Checks local file stats, returns 304 if unchanged
-- **GitHub mode** (`RESOURCES_MODE=github`): Passes conditional headers to GitHub, returns 304 if GitHub returns 304
+- **Local mode** (`RESOURCES_MODE=local`): Serves files directly from disk; conditional headers are not used and responses always include the full body
+- **GitHub mode** (`RESOURCES_MODE=github`): Passes conditional headers to GitHub and returns 304 if GitHub returns 304, skipping download and parse on cache hits
 
 No configuration changes needed - it's transparent to clients.
 

--- a/backend/doc/CONDITIONAL_FETCH_OPTIMIZATION.md
+++ b/backend/doc/CONDITIONAL_FETCH_OPTIMIZATION.md
@@ -34,7 +34,7 @@ When GitHub's content matches the client's cached ETag or hasn't been modified s
 #### 4. Short-Circuit Response
 ```typescript
 if (notModified) {
-  return sendNotModified(res, metadata);  // No parsing, immediate 304
+  return sendNotModified(res, metadata, { maxAge: config.cache.TTL });  // No parsing, immediate 304
 }
 // Only reached if content changed - process data normally
 ```

--- a/backend/doc/CONDITIONAL_FETCH_OPTIMIZATION.md
+++ b/backend/doc/CONDITIONAL_FETCH_OPTIMIZATION.md
@@ -34,7 +34,7 @@ When GitHub's content matches the client's cached ETag or hasn't been modified s
 #### 4. Short-Circuit Response
 ```typescript
 if (notModified) {
-  return sendNotModified(res, metadata, { maxAge: config.cache.TTL });  // No parsing, immediate 304
+  return sendNotModified(res, metadata, ttl, queryParams);  // No parsing, immediate 304
 }
 // Only reached if content changed - process data normally
 ```

--- a/backend/src/config/env.config.ts
+++ b/backend/src/config/env.config.ts
@@ -48,6 +48,11 @@ class EnvironmentConfig {
     TOKEN?: string;
   };
 
+  // Cache Configuration
+  readonly cache: {
+    TTL: number;
+  };
+
   // Documentation Configuration
   readonly docs: {
     BASE_URL: string;
@@ -92,6 +97,11 @@ class EnvironmentConfig {
       BRANCH: this.getString('GITHUB_BRANCH', 'main'),
       BASE_PATH: this.getString('GITHUB_BASE_PATH', 'shared/data'),
       TOKEN: process.env.GITHUB_TOKEN,
+    };
+
+    // Cache Configuration
+    this.cache = {
+      TTL: this.getNumber('CACHE_TTL', 300), // 5 minutes by default
     };
 
     // Documentation Configuration

--- a/backend/src/config/env.config.ts
+++ b/backend/src/config/env.config.ts
@@ -99,9 +99,15 @@ class EnvironmentConfig {
       TOKEN: process.env.GITHUB_TOKEN,
     };
 
-    // Cache Configuration
+    const rawCacheTTL = this.getNumber('CACHE_TTL', 300);
+    const cacheTTL =
+      !Number.isFinite(rawCacheTTL) || rawCacheTTL < 0
+        ? 0
+        : Math.floor(rawCacheTTL);
+
+    // Cache Configuration (TTL in seconds, non-negative integer)
     this.cache = {
-      TTL: this.getNumber('CACHE_TTL', 300), // 5 minutes by default
+      TTL: cacheTTL, // 5 minutes by default when env var is not set
     };
 
     // Documentation Configuration

--- a/backend/src/middleware/httpLogger.middleware.ts
+++ b/backend/src/middleware/httpLogger.middleware.ts
@@ -10,6 +10,11 @@ const requestLogger = logger.child({ component: 'HTTP' });
  */
 export function httpLogger() {
   return (req: Request, res: Response, next: NextFunction) => {
+    // Skip logging for Socket.IO polling requests (from dev tools/extensions)
+    if (req.path.startsWith('/socket.io')) {
+      return next();
+    }
+
     const startTime = Date.now();
 
     // Log incoming request

--- a/backend/src/routes/composable.routes.ts
+++ b/backend/src/routes/composable.routes.ts
@@ -1,7 +1,7 @@
 import { config } from '../config/env.config.js';
 import { Request, Response } from 'express';
 import { ApiRouter } from '../utils/api.router.js';
-import { ResourceManager, logger, checkClientCache, setCacheHeaders, sendNotModified } from '../utils/index.js';
+import { ResourceManager, logger, extractConditionalHeaders, setCacheHeaders, sendNotModified } from '../utils/index.js';
 import { sendErrorFormatted, sendFormatted } from '../utils/response.format.js';
 import {
   ComposableImageDto,
@@ -48,11 +48,12 @@ composableRouter.route({
   },
   handler: async (req: Request, res: Response) => {
     try {
-      // Load composable resource with metadata
-      const { data: composableData, metadata } = await resourceManager.getResourceWithMetadata('image/composable.json');
+      // Load composable resource with metadata, supporting conditional requests
+      const conditionalHeaders = extractConditionalHeaders(req);
+      const { data: composableData, metadata, notModified } = await resourceManager.getResourceWithMetadata('image/composable.json', conditionalHeaders);
 
-      // Check if client's cache is still valid
-      if (checkClientCache(req, metadata)) {
+      // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
+      if (notModified) {
         return sendNotModified(res, metadata);
       }
 

--- a/backend/src/routes/composable.routes.ts
+++ b/backend/src/routes/composable.routes.ts
@@ -1,7 +1,7 @@
 import { config } from '../config/env.config.js';
 import { Request, Response } from 'express';
 import { ApiRouter } from '../utils/api.router.js';
-import { ResourceManager, logger } from '../utils/index.js';
+import { ResourceManager, logger, checkClientCache, setCacheHeaders, sendNotModified } from '../utils/index.js';
 import { sendErrorFormatted, sendFormatted } from '../utils/response.format.js';
 import {
   ComposableImageDto,
@@ -48,8 +48,13 @@ composableRouter.route({
   },
   handler: async (req: Request, res: Response) => {
     try {
-      // Load composable resource
-      const composableData = await resourceManager.getResource('image/composable.json');
+      // Load composable resource with metadata
+      const { data: composableData, metadata } = await resourceManager.getResourceWithMetadata('image/composable.json');
+
+      // Check if client's cache is still valid
+      if (checkClientCache(req, metadata)) {
+        return sendNotModified(res, metadata);
+      }
 
       // Extract the "composable" object from the file
       const composableRaw = composableData.composable;
@@ -68,6 +73,9 @@ composableRouter.route({
       const composableParsed = req.headers.internal === 'true'
         ? ComposableImageSchemaDtoInternal.parse(composableRaw)
         : ComposableImageSchemaDtoPublic.parse(composableRaw);
+
+      // Set cache headers
+      setCacheHeaders(res, metadata, config.cache.TTL);
 
       // Send formatted response
       sendFormatted<ComposableImageDto>(res, composableParsed);

--- a/backend/src/routes/composable.routes.ts
+++ b/backend/src/routes/composable.routes.ts
@@ -54,7 +54,7 @@ composableRouter.route({
 
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, config.cache.TTL);
+        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
       }
 
       // Extract the "composable" object from the file

--- a/backend/src/routes/composable.routes.ts
+++ b/backend/src/routes/composable.routes.ts
@@ -54,7 +54,7 @@ composableRouter.route({
 
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata);
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
 
       // Extract the "composable" object from the file

--- a/backend/src/routes/composable.routes.ts
+++ b/backend/src/routes/composable.routes.ts
@@ -54,7 +54,7 @@ composableRouter.route({
 
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
 
       // Extract the "composable" object from the file

--- a/backend/src/routes/extension.routes.ts
+++ b/backend/src/routes/extension.routes.ts
@@ -54,7 +54,7 @@ extensionRouter.route({
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, config.cache.TTL);
+        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
       }
       
       const baseUrl = `${config.server.BASE_URL}`;
@@ -107,7 +107,7 @@ extensionRouter.route({
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, config.cache.TTL);
+        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
       }
       
       const cloudExtensions: CloudExtensions = data?.cloud || {};
@@ -169,7 +169,7 @@ extensionRouter.route({
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, config.cache.TTL);
+        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
       }
       
       const extensionEntry = data?.cloud?.[id];

--- a/backend/src/routes/extension.routes.ts
+++ b/backend/src/routes/extension.routes.ts
@@ -54,7 +54,7 @@ extensionRouter.route({
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata);
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
       
       const baseUrl = `${config.server.BASE_URL}`;

--- a/backend/src/routes/extension.routes.ts
+++ b/backend/src/routes/extension.routes.ts
@@ -3,7 +3,7 @@ import { Request, Response } from 'express';
 import { registry, z } from 'zod';
 import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { ApiRouter } from '../utils/api.router.js';
-import { ResourceManager, escapeHtml, logger, checkClientCache, setCacheHeaders, sendNotModified } from '../utils/index.js';
+import { ResourceManager, escapeHtml, logger, extractConditionalHeaders, setCacheHeaders, sendNotModified } from '../utils/index.js';
 import { ErrorDetailsSchema, HeaderAcceptSchema } from '../schemas/api.schema.js';
 import {
   RuntimeExtensionListSchema,
@@ -49,10 +49,11 @@ extensionRouter.route({
   },
   handler: async (req: Request, res: Response) => {
     try {
-      const { data, metadata } = await resourceManager.getResourceWithMetadata('extension/php_extensions.json');
+      const conditionalHeaders = extractConditionalHeaders(req);
+      const { data, metadata, notModified } = await resourceManager.getResourceWithMetadata('extension/php_extensions.json', conditionalHeaders);
       
-      // Check if client's cache is still valid
-      if (checkClientCache(req, metadata)) {
+      // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
+      if (notModified) {
         return sendNotModified(res, metadata);
       }
       
@@ -101,10 +102,11 @@ extensionRouter.route({
   },
   handler: async (req: Request, res: Response) => {
     try {
-      const { data, metadata } = await resourceManager.getResourceWithMetadata('extension/php_extensions.json');
+      const conditionalHeaders = extractConditionalHeaders(req);
+      const { data, metadata, notModified } = await resourceManager.getResourceWithMetadata('extension/php_extensions.json', conditionalHeaders);
       
-      // Check if client's cache is still valid
-      if (checkClientCache(req, metadata)) {
+      // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
+      if (notModified) {
         return sendNotModified(res, metadata);
       }
       
@@ -162,10 +164,11 @@ extensionRouter.route({
       const { id } = req.params as { id: string };
       const imageId = escapeHtml(id);
 
-      const { data, metadata } = await resourceManager.getResourceWithMetadata('extension/php_extensions.json');
+      const conditionalHeaders = extractConditionalHeaders(req);
+      const { data, metadata, notModified } = await resourceManager.getResourceWithMetadata('extension/php_extensions.json', conditionalHeaders);
       
-      // Check if client's cache is still valid
-      if (checkClientCache(req, metadata)) {
+      // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
+      if (notModified) {
         return sendNotModified(res, metadata);
       }
       

--- a/backend/src/routes/extension.routes.ts
+++ b/backend/src/routes/extension.routes.ts
@@ -107,7 +107,7 @@ extensionRouter.route({
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata);
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
       
       const cloudExtensions: CloudExtensions = data?.cloud || {};

--- a/backend/src/routes/extension.routes.ts
+++ b/backend/src/routes/extension.routes.ts
@@ -172,7 +172,7 @@ extensionRouter.route({
       const extensionEntry = data?.cloud?.[id];
 
       if (!extensionEntry) {
-        sendErrorFormatted(res, {
+        return sendErrorFormatted(res, {
           title: 'Extension not found',
           detail: `Extension "${imageId}" not found. See extra.availableExtensions for a list of valid extension IDs.`,
           status: 404,

--- a/backend/src/routes/extension.routes.ts
+++ b/backend/src/routes/extension.routes.ts
@@ -169,7 +169,7 @@ extensionRouter.route({
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata);
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
       
       const extensionEntry = data?.cloud?.[id];

--- a/backend/src/routes/extension.routes.ts
+++ b/backend/src/routes/extension.routes.ts
@@ -54,7 +54,7 @@ extensionRouter.route({
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
       
       const baseUrl = `${config.server.BASE_URL}`;
@@ -107,7 +107,7 @@ extensionRouter.route({
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
       
       const cloudExtensions: CloudExtensions = data?.cloud || {};
@@ -169,7 +169,7 @@ extensionRouter.route({
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
       
       const extensionEntry = data?.cloud?.[id];

--- a/backend/src/routes/extension.routes.ts
+++ b/backend/src/routes/extension.routes.ts
@@ -3,7 +3,7 @@ import { Request, Response } from 'express';
 import { registry, z } from 'zod';
 import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { ApiRouter } from '../utils/api.router.js';
-import { ResourceManager, escapeHtml, logger } from '../utils/index.js';
+import { ResourceManager, escapeHtml, logger, checkClientCache, setCacheHeaders, sendNotModified } from '../utils/index.js';
 import { ErrorDetailsSchema, HeaderAcceptSchema } from '../schemas/api.schema.js';
 import {
   RuntimeExtensionListSchema,
@@ -49,7 +49,13 @@ extensionRouter.route({
   },
   handler: async (req: Request, res: Response) => {
     try {
-      const data = await resourceManager.getResource('extension/php_extensions.json');
+      const { data, metadata } = await resourceManager.getResourceWithMetadata('extension/php_extensions.json');
+      
+      // Check if client's cache is still valid
+      if (checkClientCache(req, metadata)) {
+        return sendNotModified(res, metadata);
+      }
+      
       const baseUrl = `${config.server.BASE_URL}`;
 
       data.cloud = withSelfLink(data.cloud, (id) => `${baseUrl}${PATH}/cloud/${encodeURIComponent(id)}`);
@@ -57,6 +63,9 @@ extensionRouter.route({
         ...data.cloud,
         _links: { self: `${baseUrl}${PATH}/cloud` }
       };
+
+      // Set cache headers
+      setCacheHeaders(res, metadata, config.cache.TTL);
 
       sendFormatted<RuntimeExtensionList>(res, data);
     } catch (error: any) {
@@ -92,11 +101,20 @@ extensionRouter.route({
   },
   handler: async (req: Request, res: Response) => {
     try {
-      const data = await resourceManager.getResource('extension/php_extensions.json');
+      const { data, metadata } = await resourceManager.getResourceWithMetadata('extension/php_extensions.json');
+      
+      // Check if client's cache is still valid
+      if (checkClientCache(req, metadata)) {
+        return sendNotModified(res, metadata);
+      }
+      
       const cloudExtensions: CloudExtensions = data?.cloud || {};
 
       const baseUrl = `${config.server.BASE_URL}`;
       const cloudExtensionsWithLinks = withSelfLink(cloudExtensions, (id) => `${baseUrl}${PATH}/cloud/${encodeURIComponent(id)}`);
+
+      // Set cache headers
+      setCacheHeaders(res, metadata, config.cache.TTL);
 
       sendFormatted<CloudExtensions>(res, cloudExtensionsWithLinks);
     } catch (error: any) {
@@ -144,7 +162,13 @@ extensionRouter.route({
       const { id } = req.params as { id: string };
       const imageId = escapeHtml(id);
 
-      const data = await resourceManager.getResource('extension/php_extensions.json');
+      const { data, metadata } = await resourceManager.getResourceWithMetadata('extension/php_extensions.json');
+      
+      // Check if client's cache is still valid
+      if (checkClientCache(req, metadata)) {
+        return sendNotModified(res, metadata);
+      }
+      
       const extensionEntry = data?.cloud?.[id];
 
       if (!extensionEntry) {
@@ -155,6 +179,10 @@ extensionRouter.route({
           extra: { availableExtensions: Object.keys(data?.cloud || {}) }
         });
       }
+      
+      // Set cache headers
+      setCacheHeaders(res, metadata, config.cache.TTL);
+      
       sendFormatted<RuntimeExtensionVersion>(res, extensionEntry);
     } catch (error: any) {
       apiLogger.error({ error: error.message }, 'Failed to read PHP Cloud extensions');

--- a/backend/src/routes/image.routes.ts
+++ b/backend/src/routes/image.routes.ts
@@ -3,7 +3,7 @@ import { Request, Response } from 'express';
 import { z } from 'zod';
 import { ApiRouter } from '../utils/api.router.js';
 import { withSelfLink } from '../utils/api.schema.js';
-import { ResourceManager, escapeHtml, logger, checkClientCache, setCacheHeaders, sendNotModified } from '../utils/index.js';
+import { ResourceManager, escapeHtml, logger, extractConditionalHeaders, setCacheHeaders, sendNotModified } from '../utils/index.js';
 import { sendErrorFormatted, sendFormatted } from '../utils/response.format.js';
 import {
   DeployImageListDto,
@@ -53,11 +53,12 @@ imageRouter.route({
   },
   handler: async (req: Request, res: Response) => {
     try {
-      // Load registry from resources with metadata
-      const { data: registryRaw, metadata } = await resourceManager.getResourceWithMetadata('image/registry.json');
+      // Load registry from resources with metadata, supporting conditional requests
+      const conditionalHeaders = extractConditionalHeaders(req);
+      const { data: registryRaw, metadata, notModified } = await resourceManager.getResourceWithMetadata('image/registry.json', conditionalHeaders);
 
-      // Check if client's cache is still valid
-      if (checkClientCache(req, metadata)) {
+      // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
+      if (notModified) {
         return sendNotModified(res, metadata);
       }
 
@@ -122,11 +123,12 @@ imageRouter.route({
       const { id } = req.params as { id: string };
       const imageId = escapeHtml(id);
 
-      // Load registry from resources with metadata
-      const { data: registryRaw, metadata } = await resourceManager.getResourceWithMetadata('image/registry.json');
+      // Load registry from resources with metadata, supporting conditional requests
+      const conditionalHeaders = extractConditionalHeaders(req);
+      const { data: registryRaw, metadata, notModified } = await resourceManager.getResourceWithMetadata('image/registry.json', conditionalHeaders);
 
-      // Check if client's cache is still valid
-      if (checkClientCache(req, metadata)) {
+      // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
+      if (notModified) {
         return sendNotModified(res, metadata);
       }
 

--- a/backend/src/routes/image.routes.ts
+++ b/backend/src/routes/image.routes.ts
@@ -59,7 +59,7 @@ imageRouter.route({
 
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
 
       // Add self links to each image in the registry
@@ -129,7 +129,7 @@ imageRouter.route({
 
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
 
       // Check if image exists

--- a/backend/src/routes/image.routes.ts
+++ b/backend/src/routes/image.routes.ts
@@ -59,7 +59,7 @@ imageRouter.route({
 
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata);
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
 
       // Add self links to each image in the registry

--- a/backend/src/routes/image.routes.ts
+++ b/backend/src/routes/image.routes.ts
@@ -59,7 +59,7 @@ imageRouter.route({
 
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, config.cache.TTL);
+        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
       }
 
       // Add self links to each image in the registry
@@ -129,7 +129,7 @@ imageRouter.route({
 
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata);
+        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
       }
 
       // Check if image exists

--- a/backend/src/routes/image.routes.ts
+++ b/backend/src/routes/image.routes.ts
@@ -3,7 +3,7 @@ import { Request, Response } from 'express';
 import { z } from 'zod';
 import { ApiRouter } from '../utils/api.router.js';
 import { withSelfLink } from '../utils/api.schema.js';
-import { ResourceManager, escapeHtml, logger } from '../utils/index.js';
+import { ResourceManager, escapeHtml, logger, checkClientCache, setCacheHeaders, sendNotModified } from '../utils/index.js';
 import { sendErrorFormatted, sendFormatted } from '../utils/response.format.js';
 import {
   DeployImageListDto,
@@ -53,8 +53,13 @@ imageRouter.route({
   },
   handler: async (req: Request, res: Response) => {
     try {
-      // Load registry from resources
-      const registryRaw = await resourceManager.getResource('image/registry.json');
+      // Load registry from resources with metadata
+      const { data: registryRaw, metadata } = await resourceManager.getResourceWithMetadata('image/registry.json');
+
+      // Check if client's cache is still valid
+      if (checkClientCache(req, metadata)) {
+        return sendNotModified(res, metadata);
+      }
 
       // Add self links to each image in the registry
       const registryLink = withSelfLink(registryRaw, (id) => `${config.server.BASE_URL}${PATH}/${encodeURIComponent(id)}`);
@@ -63,6 +68,9 @@ imageRouter.route({
       const registryParsed = req.headers.internal === 'true'
         ? DeployImageListSchemaDtoInternal.parse(registryLink)
         : DeployImageListSchemaDtoPublic.parse(registryLink);
+
+      // Set cache headers
+      setCacheHeaders(res, metadata, config.cache.TTL);
 
       // Send formatted response
       sendFormatted<DeployImageListDto>(res, registryParsed);
@@ -114,8 +122,13 @@ imageRouter.route({
       const { id } = req.params as { id: string };
       const imageId = escapeHtml(id);
 
-      // Load registry from resources
-      const registryRaw = await resourceManager.getResource('image/registry.json');
+      // Load registry from resources with metadata
+      const { data: registryRaw, metadata } = await resourceManager.getResourceWithMetadata('image/registry.json');
+
+      // Check if client's cache is still valid
+      if (checkClientCache(req, metadata)) {
+        return sendNotModified(res, metadata);
+      }
 
       // Check if image exists
       if (!registryRaw[id]) {
@@ -135,6 +148,9 @@ imageRouter.route({
       const imageParsed = req.headers.internal === 'true'
         ? DeployImageSchemaDtoInternal.parse(imageRaw)
         : DeployImageSchemaDtoPublic.parse(imageRaw);
+
+      // Set cache headers
+      setCacheHeaders(res, metadata, config.cache.TTL);
 
       // Send formatted response
       sendFormatted<DeployImageDto>(res, imageParsed);

--- a/backend/src/routes/openapi.upsun.routes.ts
+++ b/backend/src/routes/openapi.upsun.routes.ts
@@ -69,7 +69,7 @@ openapiRouter.route({
         
         // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
         if (notModified) {
-          return sendNotModified(res, metadata);
+          return sendNotModified(res, metadata, config.cache.TTL);
         }
         
         // Set cache headers

--- a/backend/src/routes/openapi.upsun.routes.ts
+++ b/backend/src/routes/openapi.upsun.routes.ts
@@ -69,7 +69,7 @@ openapiRouter.route({
         
         // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
         if (notModified) {
-          return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
+          return sendNotModified(res, metadata, config.cache.TTL);
         }
         
         // Set cache headers

--- a/backend/src/routes/openapi.upsun.routes.ts
+++ b/backend/src/routes/openapi.upsun.routes.ts
@@ -69,7 +69,7 @@ openapiRouter.route({
         
         // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
         if (notModified) {
-          return sendNotModified(res, metadata, config.cache.TTL);
+          return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
         }
         
         // Set cache headers

--- a/backend/src/routes/openapi.upsun.routes.ts
+++ b/backend/src/routes/openapi.upsun.routes.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express';
 import { z } from 'zod';
 import { config } from '../config/env.config.js';
 import { ApiRouter } from '../utils/api.router.js';
-import { ResourceManager, logger, checkClientCache, setCacheHeaders, sendNotModified } from '../utils/index.js';
+import { ResourceManager, logger, extractConditionalHeaders, setCacheHeaders, sendNotModified } from '../utils/index.js';
 import { HeaderAcceptSchema, ErrorDetailsSchema } from '../schemas/api.schema.js';
 
 const TAG = 'OpenAPI Specification';
@@ -64,10 +64,11 @@ openapiRouter.route({
       }
       try {
         // serving the raw file according to the format with metadata
-        const { data, metadata } = await resourceManager.getResourceRawWithMetadata(`openapi/${fileName}`);
+        const conditionalHeaders = extractConditionalHeaders(req);
+        const { data, metadata, notModified } = await resourceManager.getResourceRawWithMetadata(`openapi/${fileName}`, conditionalHeaders);
         
-        // Check if client's cache is still valid
-        if (checkClientCache(req, metadata)) {
+        // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
+        if (notModified) {
           return sendNotModified(res, metadata);
         }
         

--- a/backend/src/routes/openapi.upsun.routes.ts
+++ b/backend/src/routes/openapi.upsun.routes.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from 'express';
 import { z } from 'zod';
+import { config } from '../config/env.config.js';
 import { ApiRouter } from '../utils/api.router.js';
-import { ResourceManager, logger } from '../utils/index.js';
+import { ResourceManager, logger, checkClientCache, setCacheHeaders, sendNotModified } from '../utils/index.js';
 import { HeaderAcceptSchema, ErrorDetailsSchema } from '../schemas/api.schema.js';
 
 const TAG = 'OpenAPI Specification';
@@ -62,8 +63,17 @@ openapiRouter.route({
         fileName = format === 'yaml' ? 'openapispec-upsun.yaml' : 'openapispec-upsun.json';
       }
       try {
-        // serving the raw file according to the format
-        const data = await resourceManager.getResourceRaw(`openapi/${fileName}`);
+        // serving the raw file according to the format with metadata
+        const { data, metadata } = await resourceManager.getResourceRawWithMetadata(`openapi/${fileName}`);
+        
+        // Check if client's cache is still valid
+        if (checkClientCache(req, metadata)) {
+          return sendNotModified(res, metadata);
+        }
+        
+        // Set cache headers
+        setCacheHeaders(res, metadata, config.cache.TTL);
+        
         if (format === 'yaml' && !sdks) {
           res.type('text/plain; charset=utf-8').send(data);
         } else {

--- a/backend/src/routes/region.routes.ts
+++ b/backend/src/routes/region.routes.ts
@@ -120,7 +120,10 @@ regionRouter.route({
           metadata && typeof metadata === 'object'
             ? { ...(metadata as any), etag: stripQueryHashSuffix((metadata as any).etag) }
             : metadata;
-        return sendNotModified(res, baseMetadata, queryParams);
+        return sendNotModified(res, baseMetadata, {
+          maxAge: config.cache.TTL,
+          queryParams
+        });
       }
       
       let regions = regionsData;

--- a/backend/src/routes/region.routes.ts
+++ b/backend/src/routes/region.routes.ts
@@ -2,7 +2,7 @@ import { config } from '../config/env.config.js';
 import { Request, Response } from 'express';
 import { z } from 'zod';
 import { ApiRouter } from '../utils/api.router.js';
-import { ResourceManager, escapeHtml, logger, checkClientCache, setCacheHeaders, sendNotModified } from '../utils/index.js';
+import { ResourceManager, escapeHtml, logger, extractConditionalHeaders, setCacheHeaders, sendNotModified } from '../utils/index.js';
 import { sendErrorFormatted, sendFormatted } from '../utils/response.format.js';
 import {
   HostRegionSchema,
@@ -76,17 +76,20 @@ regionRouter.route({
       const safeZone = zone ? escapeHtml(zone) : undefined;
       const safeCountryCode = country_code ? escapeHtml(country_code) : undefined;
 
-      // Get regions list with metadata
-      const { data: regionsData, metadata } = await resourceManager.getResourceWithMetadata('host/regions.json');
+      // Get regions list with metadata, supporting conditional requests
+      const conditionalHeaders = extractConditionalHeaders(req);
+      const { data: regionsData, metadata, notModified } = await resourceManager.getResourceWithMetadata('host/regions.json', conditionalHeaders);
       let regionsRecord: Record<string, any> = regionsData;
-      
+
       // Prepare query params for cache key
       const queryParams = { name, provider, zone, country_code };
       
-      // Check if client's cache is still valid (including query params in ETag)
-      if (checkClientCache(req, metadata, queryParams)) {
+      // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
+      if (notModified) {
         return sendNotModified(res, metadata, queryParams);
       }
+      
+      let regions = regionsData;
 
       // Apply filters
       if (name) {
@@ -219,10 +222,15 @@ regionRouter.route({
       const { id } = req.params as { id: string };
       const safeId = escapeHtml(id);
 
-      // Get regions list
-      const { data: regionsData, metadata } = await resourceManager.getResourceWithMetadata('host/regions.json');
+      // Get regions list with metadata, supporting conditional requests
+      const conditionalHeaders = extractConditionalHeaders(req);
+      const { data: regions, metadata, notModified } = await resourceManager.getResourceWithMetadata('host/regions.json', conditionalHeaders);
+      let regionsRecord: Record<string, any> = regions;
 
-      let regionsRecord: Record<string, any> = regionsData;
+      // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
+      if (notModified) {
+        return sendNotModified(res, metadata);
+      }
 
       // Apply filters
       if (id) {

--- a/backend/src/routes/region.routes.ts
+++ b/backend/src/routes/region.routes.ts
@@ -22,6 +22,33 @@ const apiLogger = logger.child({ component: 'API' });
 // Initialize Resource Manager
 const resourceManager = new ResourceManager();
 
+/**
+ * Strip a trailing query-hash suffix from an ETag value, if present.
+ * Example: W/"abcd1234-q1a2b3c4" -> W/"abcd1234"
+ */
+function stripQueryHashSuffix(etag: string | undefined): string | undefined {
+  if (!etag) {
+    return etag;
+  }
+  // Remove any "-q<hex>" suffix at the very end of the string (case-insensitive)
+  return etag.replace(/-q[0-9a-f]+(?="?$)/i, '');
+}
+
+/**
+ * Normalize an If-None-Match style header by removing query-hash suffixes
+ * from each ETag value while preserving multiple ETags and weak validators.
+ */
+function normalizeEtagHeader(header: string | undefined): string | undefined {
+  if (!header) {
+    return header;
+  }
+  return header
+    .split(',')
+    .map((part) => stripQueryHashSuffix(part.trim()))
+    .filter((part) => part && part.length > 0)
+    .join(', ');
+}
+
 // ========================================
 // REGION ROUTES - SINGLE SOURCE OF TRUTH
 // ========================================
@@ -77,7 +104,10 @@ regionRouter.route({
       const safeCountryCode = country_code ? escapeHtml(country_code) : undefined;
 
       // Get regions list with metadata, supporting conditional requests
-      const conditionalHeaders = extractConditionalHeaders(req);
+      const conditionalHeaders: any = extractConditionalHeaders(req);
+      if (conditionalHeaders && typeof conditionalHeaders === 'object' && 'ifNoneMatch' in conditionalHeaders) {
+        conditionalHeaders.ifNoneMatch = normalizeEtagHeader(conditionalHeaders.ifNoneMatch);
+      }
       const { data: regionsData, metadata, notModified } = await resourceManager.getResourceWithMetadata('host/regions.json', conditionalHeaders);
       let regionsRecord: Record<string, any> = regionsData;
 
@@ -86,7 +116,11 @@ regionRouter.route({
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, queryParams);
+        const baseMetadata: any =
+          metadata && typeof metadata === 'object'
+            ? { ...(metadata as any), etag: stripQueryHashSuffix((metadata as any).etag) }
+            : metadata;
+        return sendNotModified(res, baseMetadata, queryParams);
       }
       
       let regions = regionsData;

--- a/backend/src/routes/region.routes.ts
+++ b/backend/src/routes/region.routes.ts
@@ -127,10 +127,10 @@ regionRouter.route({
           metadata && typeof metadata === 'object'
             ? { ...(metadata as any), etag: stripQueryHashSuffix((metadata as any).etag) }
             : metadata;
-        return sendNotModified(res, baseMetadata, {
-          maxAge: config.cache.TTL,
+        return sendNotModified(res, baseMetadata, 
+          config.cache.TTL,
           queryParams
-        });
+        );
       }
 
       // Apply filters
@@ -271,7 +271,7 @@ regionRouter.route({
 
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
 
       // Apply filters

--- a/backend/src/routes/region.routes.ts
+++ b/backend/src/routes/region.routes.ts
@@ -3,6 +3,7 @@ import { Request, Response } from 'express';
 import { z } from 'zod';
 import { ApiRouter } from '../utils/api.router.js';
 import { ResourceManager, escapeHtml, logger, extractConditionalHeaders, setCacheHeaders, sendNotModified } from '../utils/index.js';
+import type { ConditionalHeaders } from '../utils/index.js';
 import { sendErrorFormatted, sendFormatted } from '../utils/response.format.js';
 import {
   HostRegionSchema,
@@ -104,11 +105,17 @@ regionRouter.route({
       const safeCountryCode = country_code ? escapeHtml(country_code) : undefined;
 
       // Get regions list with metadata, supporting conditional requests
-      const conditionalHeaders: any = extractConditionalHeaders(req);
-      if (conditionalHeaders && typeof conditionalHeaders === 'object' && 'ifNoneMatch' in conditionalHeaders) {
+      const rawConditionalHeaders = extractConditionalHeaders(req);
+      const conditionalHeaders: ConditionalHeaders | undefined = rawConditionalHeaders
+        ? { ...rawConditionalHeaders }
+        : undefined;
+      if (conditionalHeaders && typeof conditionalHeaders.ifNoneMatch === 'string') {
         conditionalHeaders.ifNoneMatch = normalizeEtagHeader(conditionalHeaders.ifNoneMatch);
       }
-      const { data: regionsData, metadata, notModified } = await resourceManager.getResourceWithMetadata('host/regions.json', conditionalHeaders);
+      const { data: regionsData, metadata, notModified } = await resourceManager.getResourceWithMetadata(
+        'host/regions.json',
+        conditionalHeaders
+      );
       let regionsRecord: Record<string, any> = regionsData;
 
       // Prepare query params for cache key
@@ -125,8 +132,6 @@ regionRouter.route({
           queryParams
         });
       }
-      
-      let regions = regionsData;
 
       // Apply filters
       if (name) {
@@ -266,7 +271,7 @@ regionRouter.route({
 
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata);
+        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
       }
 
       // Apply filters

--- a/backend/src/routes/region.routes.ts
+++ b/backend/src/routes/region.routes.ts
@@ -2,7 +2,7 @@ import { config } from '../config/env.config.js';
 import { Request, Response } from 'express';
 import { z } from 'zod';
 import { ApiRouter } from '../utils/api.router.js';
-import { ResourceManager, escapeHtml, logger } from '../utils/index.js';
+import { ResourceManager, escapeHtml, logger, checkClientCache, setCacheHeaders, sendNotModified } from '../utils/index.js';
 import { sendErrorFormatted, sendFormatted } from '../utils/response.format.js';
 import {
   HostRegionSchema,
@@ -76,8 +76,17 @@ regionRouter.route({
       const safeZone = zone ? escapeHtml(zone) : undefined;
       const safeCountryCode = country_code ? escapeHtml(country_code) : undefined;
 
-      // Get regions record
-      let regionsRecord: Record<string, any> = await resourceManager.getResource('host/regions.json');
+      // Get regions list with metadata
+      const { data: regionsData, metadata } = await resourceManager.getResourceWithMetadata('host/regions.json');
+      let regionsRecord: Record<string, any> = regionsData;
+      
+      // Prepare query params for cache key
+      const queryParams = { name, provider, zone, country_code };
+      
+      // Check if client's cache is still valid (including query params in ETag)
+      if (checkClientCache(req, metadata, queryParams)) {
+        return sendNotModified(res, metadata, queryParams);
+      }
 
       // Apply filters
       if (name) {
@@ -100,7 +109,7 @@ regionRouter.route({
         );
         if (Object.keys(filtered).length === 0) {
           const availableProviders = [...new Set(
-            Object.values(regionsRecord)
+            Object.values(regionsData)
               .map((r: any) => r.provider?.name)
               .filter(Boolean)
           )];
@@ -121,7 +130,7 @@ regionRouter.route({
         );
         if (Object.keys(filtered).length === 0) {
           const availableZones = [...new Set(
-            Object.values(regionsRecord)
+            Object.values(regionsData)
               .map((r: any) => r.zone)
               .filter((z: string) => z)
           )];
@@ -142,7 +151,7 @@ regionRouter.route({
         );
         if (Object.keys(filtered).length === 0) {
           const availableCountryCodes = [...new Set(
-            Object.values(regionsRecord)
+            Object.values(regionsData)
               .map((r: any) => r.country_code)
               .filter(Boolean)
           )];
@@ -161,6 +170,9 @@ regionRouter.route({
       const parsed = HostRegionsListSchema.parse(regionsRecord);
       const baseUrl = `${config.server.BASE_URL}`;
       const regionsWithLinks = withSelfLink(parsed, (id) => `${baseUrl}${PATH}/${encodeURIComponent(id)}`);
+
+      // Set cache headers with query params for proper ETag
+      setCacheHeaders(res, metadata, config.cache.TTL, queryParams);
 
       sendFormatted<HostRegionsList>(res, regionsWithLinks);
 
@@ -207,8 +219,10 @@ regionRouter.route({
       const { id } = req.params as { id: string };
       const safeId = escapeHtml(id);
 
-      // Get regions record and look up by key
-      const regionsRecord = await resourceManager.getResource('host/regions.json');
+      // Get regions list
+      const { data: regionsData, metadata } = await resourceManager.getResourceWithMetadata('host/regions.json');
+
+      let regionsRecord: Record<string, any> = regionsData;
 
       // Apply filters
       if (id) {
@@ -223,6 +237,9 @@ regionRouter.route({
             extra: { availableRegions }
           });
         }
+
+        // Set cache headers
+        setCacheHeaders(res, metadata, config.cache.TTL);
 
         return sendFormatted<HostRegion>(res, region);
       }

--- a/backend/src/routes/validation.routes.ts
+++ b/backend/src/routes/validation.routes.ts
@@ -1,7 +1,8 @@
 import { Request, Response } from 'express';
 import { z } from 'zod';
+import { config } from '../config/env.config.js';
 import { ApiRouter } from '../utils/api.router.js';
-import { ResourceManager, logger } from '../utils/index.js';
+import { ResourceManager, logger, checkClientCache, setCacheHeaders, sendNotModified } from '../utils/index.js';
 import { ErrorDetailsSchema } from '../schemas/api.schema.js';
 import { sendErrorFormatted, sendFormatted } from '../utils/response.format.js';
 import { Validation, ValidationSchema } from '../schemas/validation.schema.js';
@@ -58,7 +59,16 @@ This file is used to validate Upsun configuration files .upsun/config.yaml.
   },
   handler: async (req: Request, res: Response) => {
     try {
-      const schema = await resourceManager.getResource('validation/upsun.json');
+      const { data: schema, metadata } = await resourceManager.getResourceWithMetadata('validation/upsun.json');
+      
+      // Check if client's cache is still valid
+      if (checkClientCache(req, metadata)) {
+        return sendNotModified(res, metadata);
+      }
+      
+      // Set cache headers
+      setCacheHeaders(res, metadata, config.cache.TTL);
+      
       sendFormatted<Validation>(res, schema);
     } catch (error: any) {
       apiLogger.error({ error: error.message }, 'Failed to read Upsun validation schema');
@@ -92,7 +102,16 @@ validationRouter.route({
   },
   handler: async (req: Request, res: Response) => {
     try {
-      const schema = await resourceManager.getResource('image/registry.schema.json');
+      const { data: schema, metadata } = await resourceManager.getResourceWithMetadata('image/registry.schema.json');
+      
+      // Check if client's cache is still valid
+      if (checkClientCache(req, metadata)) {
+        return sendNotModified(res, metadata);
+      }
+      
+      // Set cache headers
+      setCacheHeaders(res, metadata, config.cache.TTL);
+      
       sendFormatted(res, schema);
     } catch (error: any) {
       apiLogger.error({ error: error.message }, 'Failed to read image registry validation schema');
@@ -142,7 +161,12 @@ The result is a JSON Schema snippet:
   },
   handler: async (req: Request, res: Response) => {
     try {
-      const registry = await resourceManager.getResource('image/registry.json');
+      const { data: registry, metadata } = await resourceManager.getResourceWithMetadata('image/registry.json');
+      
+      // Check if client's cache is still valid
+      if (checkClientCache(req, metadata)) {
+        return sendNotModified(res, metadata);
+      }
 
       const serviceSet = new Set<string>();
 
@@ -175,6 +199,9 @@ The result is a JSON Schema snippet:
         // Same service: descending semver order
         return compareSemver(verB, verA);
       });
+
+      // Set cache headers
+      setCacheHeaders(res, metadata, config.cache.TTL);
 
       res.json({
         type: 'string',
@@ -218,7 +245,12 @@ for example: \`["php:7.2", "php:7.3", "nodejs:24"]\`.
   },
   handler: async (req: Request, res: Response) => {
     try {
-      const registry = await resourceManager.getResource('image/registry.json');
+      const { data: registry, metadata } = await resourceManager.getResourceWithMetadata('image/registry.json');
+      
+      // Check if client's cache is still valid
+      if (checkClientCache(req, metadata)) {
+        return sendNotModified(res, metadata);
+      }
 
       const runtimeSet = new Set<string>();
 
@@ -252,6 +284,9 @@ for example: \`["php:7.2", "php:7.3", "nodejs:24"]\`.
         // Same runtime: descending semver order
         return compareSemver(verB, verA);
       });
+
+      // Set cache headers
+      setCacheHeaders(res, metadata, config.cache.TTL);
 
       // Return a JSON Schema snippet suitable for use as:
       // { "runtime-version": { "$ref": "https://example.com/schema/runtime-versions.json" } }

--- a/backend/src/routes/validation.routes.ts
+++ b/backend/src/routes/validation.routes.ts
@@ -108,7 +108,7 @@ validationRouter.route({
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata);
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
       
       // Set cache headers

--- a/backend/src/routes/validation.routes.ts
+++ b/backend/src/routes/validation.routes.ts
@@ -64,7 +64,7 @@ This file is used to validate Upsun configuration files .upsun/config.yaml.
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
       
       // Set cache headers
@@ -108,7 +108,7 @@ validationRouter.route({
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
       
       // Set cache headers
@@ -168,7 +168,7 @@ The result is a JSON Schema snippet:
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
 
       const serviceSet = new Set<string>();
@@ -253,7 +253,7 @@ for example: \`["php:7.2", "php:7.3", "nodejs:24"]\`.
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
 
       const runtimeSet = new Set<string>();

--- a/backend/src/routes/validation.routes.ts
+++ b/backend/src/routes/validation.routes.ts
@@ -64,7 +64,7 @@ This file is used to validate Upsun configuration files .upsun/config.yaml.
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, config.cache.TTL);
+        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
       }
       
       // Set cache headers
@@ -108,7 +108,7 @@ validationRouter.route({
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, config.cache.TTL);
+        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
       }
       
       // Set cache headers
@@ -168,7 +168,7 @@ The result is a JSON Schema snippet:
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata);
+        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
       }
 
       const serviceSet = new Set<string>();
@@ -253,7 +253,7 @@ for example: \`["php:7.2", "php:7.3", "nodejs:24"]\`.
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata, config.cache.TTL);
+        return sendNotModified(res, metadata, { maxAge: config.cache.TTL });
       }
 
       const runtimeSet = new Set<string>();

--- a/backend/src/routes/validation.routes.ts
+++ b/backend/src/routes/validation.routes.ts
@@ -253,7 +253,7 @@ for example: \`["php:7.2", "php:7.3", "nodejs:24"]\`.
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata);
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
 
       const runtimeSet = new Set<string>();

--- a/backend/src/routes/validation.routes.ts
+++ b/backend/src/routes/validation.routes.ts
@@ -2,7 +2,7 @@ import { Request, Response } from 'express';
 import { z } from 'zod';
 import { config } from '../config/env.config.js';
 import { ApiRouter } from '../utils/api.router.js';
-import { ResourceManager, logger, checkClientCache, setCacheHeaders, sendNotModified } from '../utils/index.js';
+import { ResourceManager, logger, extractConditionalHeaders, setCacheHeaders, sendNotModified } from '../utils/index.js';
 import { ErrorDetailsSchema } from '../schemas/api.schema.js';
 import { sendErrorFormatted, sendFormatted } from '../utils/response.format.js';
 import { Validation, ValidationSchema } from '../schemas/validation.schema.js';
@@ -59,10 +59,11 @@ This file is used to validate Upsun configuration files .upsun/config.yaml.
   },
   handler: async (req: Request, res: Response) => {
     try {
-      const { data: schema, metadata } = await resourceManager.getResourceWithMetadata('validation/upsun.json');
+      const conditionalHeaders = extractConditionalHeaders(req);
+      const { data: schema, metadata, notModified } = await resourceManager.getResourceWithMetadata('validation/upsun.json', conditionalHeaders);
       
-      // Check if client's cache is still valid
-      if (checkClientCache(req, metadata)) {
+      // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
+      if (notModified) {
         return sendNotModified(res, metadata);
       }
       
@@ -102,10 +103,11 @@ validationRouter.route({
   },
   handler: async (req: Request, res: Response) => {
     try {
-      const { data: schema, metadata } = await resourceManager.getResourceWithMetadata('image/registry.schema.json');
+      const conditionalHeaders = extractConditionalHeaders(req);
+      const { data: schema, metadata, notModified } = await resourceManager.getResourceWithMetadata('image/registry.schema.json', conditionalHeaders);
       
-      // Check if client's cache is still valid
-      if (checkClientCache(req, metadata)) {
+      // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
+      if (notModified) {
         return sendNotModified(res, metadata);
       }
       
@@ -161,10 +163,11 @@ The result is a JSON Schema snippet:
   },
   handler: async (req: Request, res: Response) => {
     try {
-      const { data: registry, metadata } = await resourceManager.getResourceWithMetadata('image/registry.json');
+      const conditionalHeaders = extractConditionalHeaders(req);
+      const { data: registry, metadata, notModified } = await resourceManager.getResourceWithMetadata('image/registry.json', conditionalHeaders);
       
-      // Check if client's cache is still valid
-      if (checkClientCache(req, metadata)) {
+      // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
+      if (notModified) {
         return sendNotModified(res, metadata);
       }
 
@@ -245,10 +248,11 @@ for example: \`["php:7.2", "php:7.3", "nodejs:24"]\`.
   },
   handler: async (req: Request, res: Response) => {
     try {
-      const { data: registry, metadata } = await resourceManager.getResourceWithMetadata('image/registry.json');
+      const conditionalHeaders = extractConditionalHeaders(req);
+      const { data: registry, metadata, notModified } = await resourceManager.getResourceWithMetadata('image/registry.json', conditionalHeaders);
       
-      // Check if client's cache is still valid
-      if (checkClientCache(req, metadata)) {
+      // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
+      if (notModified) {
         return sendNotModified(res, metadata);
       }
 

--- a/backend/src/routes/validation.routes.ts
+++ b/backend/src/routes/validation.routes.ts
@@ -64,7 +64,7 @@ This file is used to validate Upsun configuration files .upsun/config.yaml.
       
       // If upstream returned 304, respond with 304 (avoids unnecessary parsing)
       if (notModified) {
-        return sendNotModified(res, metadata);
+        return sendNotModified(res, metadata, config.cache.TTL);
       }
       
       // Set cache headers

--- a/backend/src/utils/cache.manager.ts
+++ b/backend/src/utils/cache.manager.ts
@@ -1,0 +1,126 @@
+import { Request, Response } from 'express';
+import { ResourceMetadata } from './resource.manager.js';
+import crypto from 'crypto';
+
+/**
+ * Generate a hash from query parameters for ETag generation
+ * @param queryParams - Query parameters object
+ * @returns Hash string or empty if no query params
+ */
+function hashQueryParams(queryParams: Record<string, any>): string {
+  // Filter out empty/undefined params and sort keys for consistency
+  const relevantParams = Object.keys(queryParams)
+    .filter(key => queryParams[key] !== undefined && queryParams[key] !== '')
+    .sort()
+    .reduce((acc, key) => {
+      acc[key] = queryParams[key];
+      return acc;
+    }, {} as Record<string, any>);
+
+  // If no params, return empty string
+  if (Object.keys(relevantParams).length === 0) {
+    return '';
+  }
+
+  // Generate a short hash of the query params
+  const paramString = JSON.stringify(relevantParams);
+  return crypto.createHash('md5').update(paramString).digest('hex').substring(0, 8);
+}
+
+/**
+ * Generate an ETag that includes query parameters for filtered responses
+ * @param baseEtag - Base ETag from the resource
+ * @param queryParams - Query parameters that affect the response
+ * @returns Enhanced ETag that includes query params
+ */
+export function generateEtagWithParams(baseEtag: string | undefined, queryParams: Record<string, any>): string | undefined {
+  if (!baseEtag) {
+    return undefined;
+  }
+
+  const queryHash = hashQueryParams(queryParams);
+  
+  // If no query params, return base etag as-is
+  if (!queryHash) {
+    return baseEtag;
+  }
+
+  // Combine base etag with query hash
+  // Remove quotes from base etag if present, add them back at the end
+  const cleanEtag = baseEtag.replace(/^"(.*)"$/, '$1');
+  return `"${cleanEtag}-q${queryHash}"`;
+}
+
+/**
+ * Check if the client's cached version matches the resource's ETag
+ * @param req - Express request object
+ * @param metadata - Resource metadata containing etag
+ * @param queryParams - Optional query parameters that affect the response
+ * @returns true if the client's cache is still valid (304 should be returned)
+ */
+export function checkClientCache(req: Request, metadata: ResourceMetadata, queryParams?: Record<string, any>): boolean {
+  const clientEtag = req.headers['if-none-match'];
+  
+  if (!clientEtag || !metadata.etag) {
+    return false;
+  }
+  
+  // Generate server-side etag with query params if provided
+  const serverEtag = queryParams 
+    ? generateEtagWithParams(metadata.etag, queryParams)
+    : metadata.etag;
+  
+  // Compare client's etag with server's etag
+  return clientEtag === serverEtag;
+}
+
+/**
+ * Set cache-related headers on the response
+ * @param res - Express response object
+ * @param metadata - Resource metadata
+ * @param maxAge - Cache max-age in seconds (default: 300 = 5 minutes)
+ * @param queryParams - Optional query parameters to include in ETag
+ */
+export function setCacheHeaders(res: Response, metadata: ResourceMetadata, maxAge: number = 300, queryParams?: Record<string, any>): void {
+  // Generate etag with query params if provided
+  const etag = queryParams 
+    ? generateEtagWithParams(metadata.etag, queryParams)
+    : metadata.etag;
+    
+  if (etag) {
+    res.setHeader('ETag', etag);
+  }
+  
+  if (metadata.lastModified) {
+    res.setHeader('Last-Modified', metadata.lastModified);
+  }
+  
+  // Set Cache-Control header
+  // - public: can be cached by browsers and CDNs
+  // - max-age: how long the cache is fresh
+  // - must-revalidate: must check with server after max-age expires
+  res.setHeader('Cache-Control', `public, max-age=${maxAge}, must-revalidate`);
+}
+
+/**
+ * Send a 304 Not Modified response
+ * @param res - Express response object
+ * @param metadata - Resource metadata (for setting etag/last-modified headers)
+ * @param queryParams - Optional query parameters to include in ETag
+ */
+export function sendNotModified(res: Response, metadata: ResourceMetadata, queryParams?: Record<string, any>): void {
+  // Generate etag with query params if provided
+  const etag = queryParams 
+    ? generateEtagWithParams(metadata.etag, queryParams)
+    : metadata.etag;
+    
+  if (etag) {
+    res.setHeader('ETag', etag);
+  }
+  
+  if (metadata.lastModified) {
+    res.setHeader('Last-Modified', metadata.lastModified);
+  }
+  
+  res.status(304).end();
+}

--- a/backend/src/utils/cache.manager.ts
+++ b/backend/src/utils/cache.manager.ts
@@ -203,8 +203,8 @@ export function setCacheHeaders(res: Response, metadata: ResourceMetadata, maxAg
 export function sendNotModified(
   res: Response,
   metadata: ResourceMetadata,
+  maxAge: number = 300,
   queryParams?: Record<string, any>,
-  maxAge: number = 300
 ): void {
   // Generate etag with query params if provided
   const etag = queryParams 

--- a/backend/src/utils/cache.manager.ts
+++ b/backend/src/utils/cache.manager.ts
@@ -1,6 +1,25 @@
 import { Request, Response } from 'express';
-import { ResourceMetadata } from './resource.manager.js';
+import { ResourceMetadata, ConditionalHeaders } from './resource.manager.js';
 import crypto from 'crypto';
+
+/**
+ * Extract conditional request headers from Express request
+ * @param req - Express request object
+ * @returns ConditionalHeaders object with If-None-Match and If-Modified-Since if present
+ */
+export function extractConditionalHeaders(req: Request): ConditionalHeaders | undefined {
+  const ifNoneMatch = req.headers['if-none-match'];
+  const ifModifiedSince = req.headers['if-modified-since'];
+
+  if (!ifNoneMatch && !ifModifiedSince) {
+    return undefined;
+  }
+
+  return {
+    ifNoneMatch: ifNoneMatch as string | undefined,
+    ifModifiedSince: ifModifiedSince as string | undefined
+  };
+}
 
 /**
  * Generate a hash from query parameters for ETag generation

--- a/backend/src/utils/cache.manager.ts
+++ b/backend/src/utils/cache.manager.ts
@@ -249,7 +249,7 @@ export function sendNotModified(
 
   // Ensure Cache-Control is present on 304 responses so caches can correctly apply/refresh TTL
   if (!res.getHeader('Cache-Control')) {
-    res.setHeader('Cache-Control', `public, max-age=${maxAge}`);
+    res.setHeader('Cache-Control', `public, max-age=${maxAge}, must-revalidate`);
   }
   
   res.status(304).end();

--- a/backend/src/utils/cache.manager.ts
+++ b/backend/src/utils/cache.manager.ts
@@ -198,8 +198,14 @@ export function setCacheHeaders(res: Response, metadata: ResourceMetadata, maxAg
  * @param res - Express response object
  * @param metadata - Resource metadata (for setting etag/last-modified headers)
  * @param queryParams - Optional query parameters to include in ETag
+ * @param maxAge - Cache max-age in seconds for the 304 response (default: 300 = 5 minutes)
  */
-export function sendNotModified(res: Response, metadata: ResourceMetadata, queryParams?: Record<string, any>): void {
+export function sendNotModified(
+  res: Response,
+  metadata: ResourceMetadata,
+  queryParams?: Record<string, any>,
+  maxAge: number = 300
+): void {
   // Generate etag with query params if provided
   const etag = queryParams 
     ? generateEtagWithParams(metadata.etag, queryParams)
@@ -239,6 +245,11 @@ export function sendNotModified(res: Response, metadata: ResourceMetadata, query
       varySet.add('Accept');
     }
     res.setHeader('Vary', Array.from(varySet).join(', '));
+  }
+
+  // Ensure Cache-Control is present on 304 responses so caches can correctly apply/refresh TTL
+  if (!res.getHeader('Cache-Control')) {
+    res.setHeader('Cache-Control', `public, max-age=${maxAge}`);
   }
   
   res.status(304).end();

--- a/backend/src/utils/cache.manager.ts
+++ b/backend/src/utils/cache.manager.ts
@@ -8,16 +8,21 @@ import crypto from 'crypto';
  * @returns ConditionalHeaders object with If-None-Match and If-Modified-Since if present
  */
 export function extractConditionalHeaders(req: Request): ConditionalHeaders | undefined {
-  const ifNoneMatch = req.headers['if-none-match'];
-  const ifModifiedSince = req.headers['if-modified-since'];
+  const rawIfNoneMatch = req.headers['if-none-match'];
+  const rawIfModifiedSince = req.headers['if-modified-since'];
+
+  const ifNoneMatch =
+    Array.isArray(rawIfNoneMatch) ? rawIfNoneMatch.join(',') : rawIfNoneMatch;
+  const ifModifiedSince =
+    Array.isArray(rawIfModifiedSince) ? rawIfModifiedSince[0] : rawIfModifiedSince;
 
   if (!ifNoneMatch && !ifModifiedSince) {
     return undefined;
   }
 
   return {
-    ifNoneMatch: ifNoneMatch as string | undefined,
-    ifModifiedSince: ifModifiedSince as string | undefined
+    ifNoneMatch,
+    ifModifiedSince
   };
 }
 

--- a/backend/src/utils/cache.manager.ts
+++ b/backend/src/utils/cache.manager.ts
@@ -52,6 +52,20 @@ export function generateEtagWithParams(baseEtag: string | undefined, queryParams
 }
 
 /**
+ * Normalize an If-None-Match header value into a list of ETags
+ * Handles string | string[] and splits on commas, trims whitespace,
+ * and strips weak validators (W/ prefix).
+ */
+function parseIfNoneMatch(headerValue: string | string[]): string[] {
+  const rawValues = Array.isArray(headerValue) ? headerValue : headerValue.split(',');
+
+  return rawValues
+    .map(value => value.trim())
+    .filter(value => value.length > 0)
+    .map(value => (value.startsWith('W/') ? value.substring(2).trim() : value));
+}
+
+/**
  * Check if the client's cached version matches the resource's ETag
  * @param req - Express request object
  * @param metadata - Resource metadata containing etag
@@ -59,19 +73,29 @@ export function generateEtagWithParams(baseEtag: string | undefined, queryParams
  * @returns true if the client's cache is still valid (304 should be returned)
  */
 export function checkClientCache(req: Request, metadata: ResourceMetadata, queryParams?: Record<string, any>): boolean {
-  const clientEtag = req.headers['if-none-match'];
-  
-  if (!clientEtag || !metadata.etag) {
+  const rawClientEtag = req.headers['if-none-match'];
+
+  if (!rawClientEtag || !metadata.etag) {
     return false;
   }
-  
+
   // Generate server-side etag with query params if provided
-  const serverEtag = queryParams 
+  const serverEtag = queryParams
     ? generateEtagWithParams(metadata.etag, queryParams)
     : metadata.etag;
-  
-  // Compare client's etag with server's etag
-  return clientEtag === serverEtag;
+
+  if (!serverEtag) {
+    return false;
+  }
+
+  // Normalize server etag (strip weak validator if present)
+  const normalizedServerEtag = serverEtag.startsWith('W/')
+    ? serverEtag.substring(2).trim()
+    : serverEtag;
+
+  // Normalize client's etag(s) and check for a match
+  const clientEtags = parseIfNoneMatch(rawClientEtag);
+  return clientEtags.includes(normalizedServerEtag);
 }
 
 /**

--- a/backend/src/utils/cache.manager.ts
+++ b/backend/src/utils/cache.manager.ts
@@ -46,9 +46,24 @@ export function generateEtagWithParams(baseEtag: string | undefined, queryParams
   }
 
   // Combine base etag with query hash
-  // Remove quotes from base etag if present, add them back at the end
-  const cleanEtag = baseEtag.replace(/^"(.*)"$/, '$1');
-  return `"${cleanEtag}-q${queryHash}"`;
+  // Normalize both strong and weak ETags:
+  // - Preserve an optional "W/" prefix
+  // - Unwrap optional quotes around the opaque tag
+  const etagMatch = baseEtag.match(/^(W\/)?\s*"?([^"]+?)"?$/);
+  let prefix: string;
+  let opaqueTag: string;
+
+  if (etagMatch) {
+    prefix = etagMatch[1] || '';
+    opaqueTag = etagMatch[2];
+  } else {
+    // Fallback: previous behavior for unexpected formats
+    prefix = '';
+    opaqueTag = baseEtag.replace(/^"(.*)"$/, '$1');
+  }
+
+  const newOpaqueTag = `${opaqueTag}-q${queryHash}`;
+  return `${prefix}"${newOpaqueTag}"`;
 }
 
 /**

--- a/backend/src/utils/cache.manager.ts
+++ b/backend/src/utils/cache.manager.ts
@@ -124,6 +124,34 @@ export function setCacheHeaders(res: Response, metadata: ResourceMetadata, maxAg
   // - max-age: how long the cache is fresh
   // - must-revalidate: must check with server after max-age expires
   res.setHeader('Cache-Control', `public, max-age=${maxAge}, must-revalidate`);
+
+  // Ensure Vary: Accept is present so caches know the response varies by Accept header
+  const existingVary = res.getHeader('Vary');
+  if (existingVary === undefined) {
+    res.setHeader('Vary', 'Accept');
+  } else {
+    const headerValue = Array.isArray(existingVary)
+      ? existingVary.join(',')
+      : String(existingVary);
+    const varySet = new Set<string>();
+    headerValue.split(',').forEach(value => {
+      const trimmed = value.trim();
+      if (trimmed) {
+        varySet.add(trimmed);
+      }
+    });
+    let hasAccept = false;
+    for (const v of varySet) {
+      if (v.toLowerCase() === 'accept') {
+        hasAccept = true;
+        break;
+      }
+    }
+    if (!hasAccept) {
+      varySet.add('Accept');
+    }
+    res.setHeader('Vary', Array.from(varySet).join(', '));
+  }
 }
 
 /**
@@ -144,6 +172,34 @@ export function sendNotModified(res: Response, metadata: ResourceMetadata, query
   
   if (metadata.lastModified) {
     res.setHeader('Last-Modified', metadata.lastModified);
+  }
+
+  // Mirror Vary: Accept on 304 responses so caches handle negotiated variants correctly
+  const existingVary = res.getHeader('Vary');
+  if (existingVary === undefined) {
+    res.setHeader('Vary', 'Accept');
+  } else {
+    const headerValue = Array.isArray(existingVary)
+      ? existingVary.join(',')
+      : String(existingVary);
+    const varySet = new Set<string>();
+    headerValue.split(',').forEach(value => {
+      const trimmed = value.trim();
+      if (trimmed) {
+        varySet.add(trimmed);
+      }
+    });
+    let hasAccept = false;
+    for (const v of varySet) {
+      if (v.toLowerCase() === 'accept') {
+        hasAccept = true;
+        break;
+      }
+    }
+    if (!hasAccept) {
+      varySet.add('Accept');
+    }
+    res.setHeader('Vary', Array.from(varySet).join(', '));
   }
   
   res.status(304).end();

--- a/backend/src/utils/index.ts
+++ b/backend/src/utils/index.ts
@@ -4,8 +4,8 @@
  */
 
 export { logger, configureLogger } from './logger.js';
-export { ResourceManager, type ResourceMetadata, type ResourceWithMetadata } from './resource.manager.js';
-export { checkClientCache, setCacheHeaders, sendNotModified, generateEtagWithParams } from './cache.manager.js';
+export { ResourceManager, type ResourceMetadata, type ResourceWithMetadata, type ConditionalHeaders } from './resource.manager.js';
+export { checkClientCache, setCacheHeaders, sendNotModified, generateEtagWithParams, extractConditionalHeaders } from './cache.manager.js';
 
 export function escapeHtml(unsafe: string): string {
   return unsafe.replaceAll(/[&<>"']/g, (char) => {

--- a/backend/src/utils/index.ts
+++ b/backend/src/utils/index.ts
@@ -4,7 +4,8 @@
  */
 
 export { logger, configureLogger } from './logger.js';
-export { ResourceManager } from './resource.manager.js';
+export { ResourceManager, type ResourceMetadata, type ResourceWithMetadata } from './resource.manager.js';
+export { checkClientCache, setCacheHeaders, sendNotModified, generateEtagWithParams } from './cache.manager.js';
 
 export function escapeHtml(unsafe: string): string {
   return unsafe.replaceAll(/[&<>"']/g, (char) => {

--- a/backend/src/utils/resource.manager.ts
+++ b/backend/src/utils/resource.manager.ts
@@ -188,9 +188,8 @@ export class ResourceManager {
    * Read raw resource content from local file system with metadata
    */
   private getLocalResourceRawWithMetadata(filePath: string): ResourceWithMetadata<string> {
-    const projectRoot = path.resolve(__dirname, '../../..');
-    const resourcesBase = path.resolve(projectRoot, 'resources');
-    const fullPath = this.resolveLocalPath(resourcesBase, filePath);
+    const localBase = path.resolve(__dirname, this.config.localPath!);
+    const fullPath = this.resolveLocalPath(localBase, filePath);
 
     try {
       const content = fs.readFileSync(fullPath, 'utf-8');

--- a/backend/src/utils/resource.manager.ts
+++ b/backend/src/utils/resource.manager.ts
@@ -24,6 +24,17 @@ interface ResourceConfig {
   };
 }
 
+export interface ResourceMetadata {
+  etag?: string;
+  lastModified?: string;
+  source: 'local' | 'github';
+}
+
+export interface ResourceWithMetadata<T = any> {
+  data: T;
+  metadata: ResourceMetadata;
+}
+
 export class ResourceManager {
   private config: ResourceConfig;
 
@@ -48,6 +59,18 @@ export class ResourceManager {
   }
 
   /**
+   * Get the content of a resource file with metadata (etag, last-modified)
+   * @param filePath - Relative path to the file (e.g., 'image/registry.json')
+   */
+  async getResourceWithMetadata(filePath: string): Promise<ResourceWithMetadata> {
+    if (this.config.mode === 'local') {
+      return this.getLocalResourceWithMetadata(filePath);
+    } else {
+      return this.getGithubResourceWithMetadata(filePath);
+    }
+  }
+
+  /**
    * Get raw content of a resource file (no parsing)
    * @param filePath - Relative path to the file (e.g., 'image/registry.json')
    */
@@ -56,6 +79,18 @@ export class ResourceManager {
       return this.getLocalResourceRaw(filePath);
     } else {
       return this.getGithubResourceRaw(filePath);
+    }
+  }
+
+  /**
+   * Get raw content of a resource file with metadata (no parsing)
+   * @param filePath - Relative path to the file (e.g., 'image/registry.json')
+   */
+  async getResourceRawWithMetadata(filePath: string): Promise<ResourceWithMetadata<string>> {
+    if (this.config.mode === 'local') {
+      return this.getLocalResourceRawWithMetadata(filePath);
+    } else {
+      return this.getGithubResourceRawWithMetadata(filePath);
     }
   }
 
@@ -91,6 +126,40 @@ export class ResourceManager {
   }
 
   /**
+   * Read resource from local file system with metadata
+   */
+  private getLocalResourceWithMetadata(filePath: string): ResourceWithMetadata {
+    const projectRoot = path.resolve(__dirname, '../../..');
+    const resourcesBase = path.resolve(projectRoot, 'resources');
+    const fullPath = this.resolveLocalPath(resourcesBase, filePath);
+
+    try {
+      const content = fs.readFileSync(fullPath, 'utf-8');
+      const stats = fs.statSync(fullPath);
+      
+      const ext = path.extname(fullPath).toLowerCase();
+      const data = (ext === '.yaml' || ext === '.yml') ? YAML.parse(content) : JSON.parse(content);
+      
+      // Generate etag from file stats (mtime + size)
+      const etag = `"${stats.mtime.getTime()}-${stats.size}"`;
+      
+      resourceLogger.info({ filePath, fullPath, etag }, 'Local resource with metadata read successfully');
+      
+      return {
+        data,
+        metadata: {
+          etag,
+          lastModified: stats.mtime.toUTCString(),
+          source: 'local'
+        }
+      };
+    } catch (error: any) {
+      resourceLogger.error({ filePath, fullPath, error: error.message }, 'Failed to read local resource with metadata');
+      throw new Error(`Unable to read local resource: ${filePath}`);
+    }
+  }
+
+  /**
    * Read raw resource content from local file system
    */
   private getLocalResourceRaw(filePath: string): string {
@@ -111,6 +180,37 @@ export class ResourceManager {
       return content;
     } catch (error: any) {
       resourceLogger.error({ filePath, fullPath, error: error.message }, 'Failed to read local raw resource');
+      throw new Error(`Unable to read local raw resource: ${filePath}`);
+    }
+  }
+
+  /**
+   * Read raw resource content from local file system with metadata
+   */
+  private getLocalResourceRawWithMetadata(filePath: string): ResourceWithMetadata<string> {
+    const projectRoot = path.resolve(__dirname, '../../..');
+    const resourcesBase = path.resolve(projectRoot, 'resources');
+    const fullPath = this.resolveLocalPath(resourcesBase, filePath);
+
+    try {
+      const content = fs.readFileSync(fullPath, 'utf-8');
+      const stats = fs.statSync(fullPath);
+      
+      // Generate etag from file stats (mtime + size)
+      const etag = `"${stats.mtime.getTime()}-${stats.size}"`;
+      
+      resourceLogger.info({ filePath, fullPath, etag }, 'Local raw resource with metadata read successfully');
+      
+      return {
+        data: content,
+        metadata: {
+          etag,
+          lastModified: stats.mtime.toUTCString(),
+          source: 'local'
+        }
+      };
+    } catch (error: any) {
+      resourceLogger.error({ filePath, fullPath, error: error.message }, 'Failed to read local raw resource with metadata');
       throw new Error(`Unable to read local raw resource: ${filePath}`);
     }
   }
@@ -188,6 +288,65 @@ export class ResourceManager {
   }
 
   /**
+   * Fetch resource from GitHub repository with metadata (etag, last-modified)
+   */
+  private async getGithubResourceWithMetadata(filePath: string): Promise<ResourceWithMetadata> {
+    const { REPO_OWNER: owner, REPO_NAME: repo, BRANCH: branch, BASE_PATH: basePath, TOKEN: token } = this.config.githubConfig!;
+
+    if (!owner || !repo) {
+      throw new Error('GitHub configuration is incomplete');
+    }
+
+    const fullPath = basePath ? `${basePath}/${filePath}` : filePath;
+    const url = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${fullPath}`;
+
+    resourceLogger.debug({ mode: this.config.mode, url }, 'Fetching resource with metadata from GitHub');
+
+    try {
+      const headers: Record<string, string> = {};
+      if (token) {
+        headers['Authorization'] = `token ${token}`;
+      }
+
+      const response = await fetch(url, { headers });
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          resourceLogger.error({ filePath, url }, 'File not found on GitHub');
+          throw new Error(`File not found on GitHub: ${filePath}`);
+        }
+        resourceLogger.error({ status: response.status, url }, 'HTTP error fetching from GitHub');
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      // Extract metadata from GitHub response headers
+      const etag = response.headers.get('etag') || undefined;
+      const lastModified = response.headers.get('last-modified') || undefined;
+
+      const ext = path.extname(filePath).toLowerCase();
+      const text = await response.text();
+      const data = (ext === '.yaml' || ext === '.yml') ? YAML.parse(text) : JSON.parse(text);
+
+      resourceLogger.info({ filePath, url, etag, lastModified }, 'Successfully fetched from GitHub with metadata');
+
+      return {
+        data,
+        metadata: {
+          etag,
+          lastModified,
+          source: 'github'
+        }
+      };
+    } catch (error) {
+      if (error instanceof Error) {
+        resourceLogger.error({ error: error.message, url }, 'Failed to fetch from GitHub with metadata');
+        throw new Error(`Unable to fetch from GitHub: ${error.message} (URL: ${url})`);
+      }
+      throw new Error('Unable to fetch resource from GitHub');
+    }
+  }
+
+  /**
    * Fetch raw resource content from GitHub repository
    */
   private async getGithubResourceRaw(filePath: string): Promise<string> {
@@ -224,6 +383,63 @@ export class ResourceManager {
     } catch (error) {
       if (error instanceof Error) {
         resourceLogger.error({ error: error.message, url }, 'Failed to fetch raw from GitHub');
+        throw new Error(`Unable to fetch raw from GitHub: ${error.message} (URL: ${url})`);
+      }
+      throw new Error('Unable to fetch raw resource from GitHub');
+    }
+  }
+
+  /**
+   * Fetch raw resource content from GitHub repository with metadata
+   */
+  private async getGithubResourceRawWithMetadata(filePath: string): Promise<ResourceWithMetadata<string>> {
+    const { REPO_OWNER: owner, REPO_NAME: repo, BRANCH: branch, BASE_PATH: basePath, TOKEN: token } = this.config.githubConfig!;
+
+    if (!owner || !repo) {
+      throw new Error('GitHub configuration is incomplete');
+    }
+
+    const fullPath = basePath ? `${basePath}/${filePath}` : filePath;
+    const url = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${fullPath}`;
+
+    resourceLogger.debug({ mode: this.config.mode, url }, 'Fetching raw resource with metadata from GitHub');
+
+    try {
+      const headers: Record<string, string> = {};
+      if (token) {
+        headers['Authorization'] = `token ${token}`;
+      }
+
+      const response = await fetch(url, { headers });
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          resourceLogger.error({ filePath, url }, 'File not found on GitHub');
+          throw new Error(`File not found on GitHub: ${filePath}`);
+        }
+        resourceLogger.error({ status: response.status, url }, 'HTTP error fetching raw from GitHub');
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      // Extract metadata from GitHub response headers
+      const etag = response.headers.get('etag') || undefined;
+      const lastModified = response.headers.get('last-modified') || undefined;
+
+      const data = await response.text();
+
+      resourceLogger.info({ filePath, url, etag, lastModified }, 'Successfully fetched raw from GitHub with metadata');
+
+      return {
+        data,
+        metadata: {
+          etag,
+          lastModified,
+          source: 'github'
+        }
+      };
+    } catch (error) {
+      if (error instanceof Error) {
+        resourceLogger.error({ error: error.message, url }, 'Failed to fetch raw from GitHub with metadata');
         throw new Error(`Unable to fetch raw from GitHub: ${error.message} (URL: ${url})`);
       }
       throw new Error('Unable to fetch raw resource from GitHub');

--- a/backend/src/utils/resource.manager.ts
+++ b/backend/src/utils/resource.manager.ts
@@ -31,7 +31,7 @@ export interface ResourceMetadata {
 }
 
 export interface ResourceWithMetadata<T = any> {
-  data: T;
+  data?: T;
   metadata: ResourceMetadata;
   notModified?: boolean; // True when upstream returns 304 (data will be undefined)
 }

--- a/backend/src/utils/resource.manager.ts
+++ b/backend/src/utils/resource.manager.ts
@@ -33,6 +33,12 @@ export interface ResourceMetadata {
 export interface ResourceWithMetadata<T = any> {
   data: T;
   metadata: ResourceMetadata;
+  notModified?: boolean; // True when upstream returns 304 (data will be undefined)
+}
+
+export interface ConditionalHeaders {
+  ifNoneMatch?: string;
+  ifModifiedSince?: string;
 }
 
 export class ResourceManager {
@@ -60,13 +66,15 @@ export class ResourceManager {
 
   /**
    * Get the content of a resource file with metadata (etag, last-modified)
+   * Supports conditional requests for GitHub mode to avoid unnecessary downloads
    * @param filePath - Relative path to the file (e.g., 'image/registry.json')
+   * @param conditionalHeaders - Optional If-None-Match/If-Modified-Since headers for conditional requests
    */
-  async getResourceWithMetadata(filePath: string): Promise<ResourceWithMetadata> {
+  async getResourceWithMetadata(filePath: string, conditionalHeaders?: ConditionalHeaders): Promise<ResourceWithMetadata> {
     if (this.config.mode === 'local') {
       return this.getLocalResourceWithMetadata(filePath);
     } else {
-      return this.getGithubResourceWithMetadata(filePath);
+      return this.getGithubResourceWithMetadata(filePath, conditionalHeaders);
     }
   }
 
@@ -84,13 +92,15 @@ export class ResourceManager {
 
   /**
    * Get raw content of a resource file with metadata (no parsing)
+   * Supports conditional requests for GitHub mode to avoid unnecessary downloads
    * @param filePath - Relative path to the file (e.g., 'image/registry.json')
+   * @param conditionalHeaders - Optional If-None-Match/If-Modified-Since headers for conditional requests
    */
-  async getResourceRawWithMetadata(filePath: string): Promise<ResourceWithMetadata<string>> {
+  async getResourceRawWithMetadata(filePath: string, conditionalHeaders?: ConditionalHeaders): Promise<ResourceWithMetadata<string>> {
     if (this.config.mode === 'local') {
       return this.getLocalResourceRawWithMetadata(filePath);
     } else {
-      return this.getGithubResourceRawWithMetadata(filePath);
+      return this.getGithubResourceRawWithMetadata(filePath, conditionalHeaders);
     }
   }
 
@@ -288,8 +298,9 @@ export class ResourceManager {
 
   /**
    * Fetch resource from GitHub repository with metadata (etag, last-modified)
+   * Supports conditional requests to avoid unnecessary downloads
    */
-  private async getGithubResourceWithMetadata(filePath: string): Promise<ResourceWithMetadata> {
+  private async getGithubResourceWithMetadata(filePath: string, conditionalHeaders?: ConditionalHeaders): Promise<ResourceWithMetadata> {
     const { REPO_OWNER: owner, REPO_NAME: repo, BRANCH: branch, BASE_PATH: basePath, TOKEN: token } = this.config.githubConfig!;
 
     if (!owner || !repo) {
@@ -299,15 +310,37 @@ export class ResourceManager {
     const fullPath = basePath ? `${basePath}/${filePath}` : filePath;
     const url = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${fullPath}`;
 
-    resourceLogger.debug({ mode: this.config.mode, url }, 'Fetching resource with metadata from GitHub');
+    resourceLogger.debug({ mode: this.config.mode, url, conditionalHeaders }, 'Fetching resource with metadata from GitHub');
 
     try {
       const headers: Record<string, string> = {};
       if (token) {
         headers['Authorization'] = `token ${token}`;
       }
+      
+      // Add conditional request headers if provided
+      if (conditionalHeaders?.ifNoneMatch) {
+        headers['If-None-Match'] = conditionalHeaders.ifNoneMatch;
+      }
+      if (conditionalHeaders?.ifModifiedSince) {
+        headers['If-Modified-Since'] = conditionalHeaders.ifModifiedSince;
+      }
 
       const response = await fetch(url, { headers });
+
+      // Handle 304 Not Modified from GitHub
+      if (response.status === 304) {
+        resourceLogger.info({ filePath, url }, 'GitHub returned 304 Not Modified - cache still valid');
+        return {
+          data: undefined as any, // Data not needed when notModified is true
+          metadata: {
+            etag: conditionalHeaders?.ifNoneMatch,
+            lastModified: conditionalHeaders?.ifModifiedSince,
+            source: 'github'
+          },
+          notModified: true
+        };
+      }
 
       if (!response.ok) {
         if (response.status === 404) {
@@ -334,7 +367,8 @@ export class ResourceManager {
           etag,
           lastModified,
           source: 'github'
-        }
+        },
+        notModified: false
       };
     } catch (error) {
       if (error instanceof Error) {
@@ -390,8 +424,9 @@ export class ResourceManager {
 
   /**
    * Fetch raw resource content from GitHub repository with metadata
+   * Supports conditional requests to avoid unnecessary downloads
    */
-  private async getGithubResourceRawWithMetadata(filePath: string): Promise<ResourceWithMetadata<string>> {
+  private async getGithubResourceRawWithMetadata(filePath: string, conditionalHeaders?: ConditionalHeaders): Promise<ResourceWithMetadata<string>> {
     const { REPO_OWNER: owner, REPO_NAME: repo, BRANCH: branch, BASE_PATH: basePath, TOKEN: token } = this.config.githubConfig!;
 
     if (!owner || !repo) {
@@ -401,7 +436,7 @@ export class ResourceManager {
     const fullPath = basePath ? `${basePath}/${filePath}` : filePath;
     const url = `https://raw.githubusercontent.com/${owner}/${repo}/${branch}/${fullPath}`;
 
-    resourceLogger.debug({ mode: this.config.mode, url }, 'Fetching raw resource with metadata from GitHub');
+    resourceLogger.debug({ mode: this.config.mode, url, conditionalHeaders }, 'Fetching raw resource with metadata from GitHub');
 
     try {
       const headers: Record<string, string> = {};
@@ -409,7 +444,29 @@ export class ResourceManager {
         headers['Authorization'] = `token ${token}`;
       }
 
+      // Add conditional request headers if provided
+      if (conditionalHeaders?.ifNoneMatch) {
+        headers['If-None-Match'] = conditionalHeaders.ifNoneMatch;
+      }
+      if (conditionalHeaders?.ifModifiedSince) {
+        headers['If-Modified-Since'] = conditionalHeaders.ifModifiedSince;
+      }
+
       const response = await fetch(url, { headers });
+
+      // Handle 304 Not Modified from GitHub
+      if (response.status === 304) {
+        resourceLogger.info({ filePath, url }, 'GitHub returned 304 Not Modified for raw resource - cache still valid');
+        return {
+          data: undefined as any, // Data not needed when notModified is true
+          metadata: {
+            etag: conditionalHeaders?.ifNoneMatch,
+            lastModified: conditionalHeaders?.ifModifiedSince,
+            source: 'github'
+          },
+          notModified: true
+        };
+      }
 
       if (!response.ok) {
         if (response.status === 404) {
@@ -434,7 +491,8 @@ export class ResourceManager {
           etag,
           lastModified,
           source: 'github'
-        }
+        },
+        notModified: false
       };
     } catch (error) {
       if (error instanceof Error) {

--- a/backend/src/utils/resource.manager.ts
+++ b/backend/src/utils/resource.manager.ts
@@ -456,12 +456,15 @@ export class ResourceManager {
 
       // Handle 304 Not Modified from GitHub
       if (response.status === 304) {
-        resourceLogger.info({ filePath, url }, 'GitHub returned 304 Not Modified for raw resource - cache still valid');
+        const etag = response.headers.get('etag') || conditionalHeaders?.ifNoneMatch;
+        const lastModified = response.headers.get('last-modified') || conditionalHeaders?.ifModifiedSince;
+
+        resourceLogger.info({ filePath, url, etag, lastModified }, 'GitHub returned 304 Not Modified for raw resource - cache still valid');
         return {
           data: undefined as any, // Data not needed when notModified is true
           metadata: {
-            etag: conditionalHeaders?.ifNoneMatch,
-            lastModified: conditionalHeaders?.ifModifiedSince,
+            etag,
+            lastModified,
             source: 'github'
           },
           notModified: true

--- a/backend/src/utils/resource.manager.ts
+++ b/backend/src/utils/resource.manager.ts
@@ -65,10 +65,12 @@ export class ResourceManager {
   }
 
   /**
-   * Get the content of a resource file with metadata (etag, last-modified)
-   * Supports conditional requests for GitHub mode to avoid unnecessary downloads
+   * Get the content of a resource file with metadata (etag, last-modified).
+   * Supports conditional requests (If-None-Match / If-Modified-Since, 304/notModified)
+   * for GitHub mode only to avoid unnecessary downloads. In local mode, any
+   * provided conditionalHeaders are ignored and notModified will never be set.
    * @param filePath - Relative path to the file (e.g., 'image/registry.json')
-   * @param conditionalHeaders - Optional If-None-Match/If-Modified-Since headers for conditional requests
+   * @param conditionalHeaders - Optional If-None-Match/If-Modified-Since headers for conditional requests (GitHub mode only)
    */
   async getResourceWithMetadata(filePath: string, conditionalHeaders?: ConditionalHeaders): Promise<ResourceWithMetadata> {
     if (this.config.mode === 'local') {
@@ -91,10 +93,12 @@ export class ResourceManager {
   }
 
   /**
-   * Get raw content of a resource file with metadata (no parsing)
-   * Supports conditional requests for GitHub mode to avoid unnecessary downloads
+   * Get raw content of a resource file with metadata (no parsing).
+   * Supports conditional requests (If-None-Match / If-Modified-Since, 304/notModified)
+   * for GitHub mode only to avoid unnecessary downloads. In local mode, any
+   * provided conditionalHeaders are ignored and notModified will never be set.
    * @param filePath - Relative path to the file (e.g., 'image/registry.json')
-   * @param conditionalHeaders - Optional If-None-Match/If-Modified-Since headers for conditional requests
+   * @param conditionalHeaders - Optional If-None-Match/If-Modified-Since headers for conditional requests (GitHub mode only)
    */
   async getResourceRawWithMetadata(filePath: string, conditionalHeaders?: ConditionalHeaders): Promise<ResourceWithMetadata<string>> {
     if (this.config.mode === 'local') {

--- a/backend/src/utils/resource.manager.ts
+++ b/backend/src/utils/resource.manager.ts
@@ -334,12 +334,15 @@ export class ResourceManager {
 
       // Handle 304 Not Modified from GitHub
       if (response.status === 304) {
-        resourceLogger.info({ filePath, url }, 'GitHub returned 304 Not Modified - cache still valid');
+        // Prefer metadata from GitHub response headers; fall back to conditional headers if missing
+        const etag = response.headers.get('etag') || conditionalHeaders?.ifNoneMatch || undefined;
+        const lastModified = response.headers.get('last-modified') || conditionalHeaders?.ifModifiedSince || undefined;
+        resourceLogger.info({ filePath, url, etag, lastModified }, 'GitHub returned 304 Not Modified - cache still valid');
         return {
           data: undefined as any, // Data not needed when notModified is true
           metadata: {
-            etag: conditionalHeaders?.ifNoneMatch,
-            lastModified: conditionalHeaders?.ifModifiedSince,
+            etag,
+            lastModified,
             source: 'github'
           },
           notModified: true


### PR DESCRIPTION
* cache key with computation of the file mimetime + optionnal params
* CACHE_TTL envVar added everywhere (default to 300ms)
* send corresponding headers
* send Etag to the response
* envVar CACHE_TTL already added to the Meta Registry Upsun project
* ETag Implementation Test Report

## Test Summary
All API routes have been tested successfully. The ETag implementation is working correctly across all endpoints with proper caching, 304 Not Modified responses, and unique ETags for filtered queries.

Test Results

/images - Container Images
Status: ✅ Pass
HTTP Code: 200 OK
ETag: "1773391306186-305001"
Last-Modified: Fri, 13 Mar 2026 08:41:46 GMT
Cache-Control: public, max-age=300, must-revalidate
Content-Length: 15,605 bytes
/images - 304 Not Modified Test
Status: ✅ Pass
HTTP Code: 304 Not Modified
If-None-Match: "1773391306186-305001"
Response: Empty body (bandwidth saved)
Headers: Same ETag returned, confirming client cache validity
/composable - Composable Images
Status: ✅ Pass
HTTP Code: 200 OK
ETag: "1773391306185-893"
Last-Modified: Fri, 13 Mar 2026 08:41:45 GMT
Cache-Control: public, max-age=300, must-revalidate
/regions - All Regions (unfiltered)
Status: ✅ Pass
HTTP Code: 200 OK
ETag: "1773391306182-99083"
Last-Modified: Fri, 13 Mar 2026 08:41:46 GMT
Cache-Control: public, max-age=300, must-revalidate
Content: Full regions list (15+ regions, multiple providers)
/regions?provider=AWS - Filtered Regions
Status: ✅ Pass
HTTP Code: 200 OK
ETag: "1773391306182-99083-qa7394265" (with query hash suffix)
Last-Modified: Fri, 13 Mar 2026 08:41:46 GMT
Cache-Control: public, max-age=300, must-revalidate
Content: AWS regions only (6 regions)
Query Hash: qa7394265 uniquely identifies the provider=AWS filter
/regions?provider=Azure - Filtered Regions (different filter)
Status: ✅ Pass
HTTP Code: 200 OK
ETag: "1773391306182-99083-qf4ba701f" (different query hash)
Last-Modified: Fri, 13 Mar 2026 08:41:46 GMT
Cache-Control: public, max-age=300, must-revalidate
Content: Azure regions only (3 regions)
Query Hash: qf4ba701f uniquely identifies the provider=Azure filter
Validation: ✅ Different hash from AWS filter confirms proper query parameter differentiation
/openapi-spec - OpenAPI Specification
Status: ✅ Pass
HTTP Code: 200 OK
ETag: "1773307872197-972812"
Last-Modified: Thu, 12 Mar 2026 09:31:12 GMT
Cache-Control: public, max-age=300, must-revalidate
Content-Length: 972,812 bytes (large spec file)
/extensions/php - PHP Extensions
Status: ✅ Pass
HTTP Code: 200 OK
ETag: "1773332487904-144236"
Last-Modified: Thu, 12 Mar 2026 16:21:27 GMT
Cache-Control: public, max-age=300, must-revalidate
Content-Length: 78,473 bytes
/schema/upsun - Upsun Validation Schema
Status: ✅ Pass
HTTP Code: 200 OK
ETag: "1773307872204-60016"
Last-Modified: Thu, 12 Mar 2026 09:31:12 GMT
Cache-Control: public, max-age=300, must-revalidate
Content-Length: 39,819 bytes
Key Findings
✅ Successful Implementation
All routes support ETags: Every API endpoint returns proper ETag and Last-Modified headers
304 Not Modified works: Validated with If-None-Match request header
Query parameter hashing functional: Filtered routes generate unique ETags
Base file ETag: 1773391306182-99083
AWS filtered ETag: 1773391306182-99083-qa7394265
Azure filtered ETag: 1773391306182-99083-qf4ba701f

* Consistent cache TTL: All routes use 300-second (5-minute) cache duration from CACHE_TTL environment variable
* Proper cache headers: Cache-Control: public, max-age=300, must-revalidate on all responses

## Cache Collision Prevention
The query parameter hashing successfully prevents cache collisions:
Same base file (regions.json) generates different ETags based on query filters
Clients can cache filtered and unfiltered responses independently
No risk of serving AWS data when requesting Azure data

## Performance Benefits
Bandwidth savings: 304 responses send only headers (no body)
Client-side caching: Mintlify and other consumers can cache for up to 5 minutes
CDN compatibility: public cache-control allows intermediate caching
Conditional requests: must-revalidate ensures freshness checks after expiry

## Configuration
Cache TTL: Configurable via `CACHE_TTL` environment variable (default: 300 seconds)
ETag format:
Unfiltered: "{timestamp}-{size}"
Filtered: "{timestamp}-{size}-q{md5_hash}"
Query hash: MD5 (truncated to 8 characters) of sorted, normalized query parameters