### PR TITLE
Disable ETag generation and caching

### DIFF
--- a/backend/src/utils/cache.manager.ts
+++ b/backend/src/utils/cache.manager.ts
@@ -85,7 +85,7 @@ export function generateEtagWithParams(baseEtag: string | undefined, queryParams
   }
 
   const queryHash = hashQueryParams(queryParams);
-  
+
   // If no query params, return base etag as-is
   if (!queryHash) {
     return baseEtag;
@@ -166,51 +166,53 @@ export function checkClientCache(req: Request, metadata: ResourceMetadata, query
  * @param queryParams - Optional query parameters to include in ETag
  */
 export function setCacheHeaders(res: Response, metadata: ResourceMetadata, maxAge: number = 300, queryParams?: Record<string, any>): void {
-  // Generate ETag with request-sensitive context (Accept variant + optional query params)
-  const etagContext = buildEtagContext(res.req, queryParams);
-  const etag = generateEtagWithParams(metadata.etag, etagContext);
-    
-  if (etag) {
-    res.setHeader('ETag', etag);
-  }
-  
-  if (metadata.lastModified) {
-    res.setHeader('Last-Modified', metadata.lastModified);
-  }
-  
-  // Set Cache-Control header
-  // - public: can be cached by browsers and CDNs
-  // - max-age: how long the cache is fresh
-  // - must-revalidate: must check with server after max-age expires
-  res.setHeader('Cache-Control', `public, max-age=${maxAge}, must-revalidate`);
+  // Disable caching for now while we iterate on ETag logic and monitor cache behavior in production. We will re-enable with proper ETag handling once we are confident in the implementation.
 
-  // Ensure Vary: Accept is present so caches know the response varies by Accept header
-  const existingVary = res.getHeader('Vary');
-  if (existingVary === undefined) {
-    res.setHeader('Vary', 'Accept');
-  } else {
-    const headerValue = Array.isArray(existingVary)
-      ? existingVary.join(',')
-      : String(existingVary);
-    const varySet = new Set<string>();
-    headerValue.split(',').forEach(value => {
-      const trimmed = value.trim();
-      if (trimmed) {
-        varySet.add(trimmed);
-      }
-    });
-    let hasAccept = false;
-    for (const v of varySet) {
-      if (v.toLowerCase() === 'accept') {
-        hasAccept = true;
-        break;
-      }
-    }
-    if (!hasAccept) {
-      varySet.add('Accept');
-    }
-    res.setHeader('Vary', Array.from(varySet).join(', '));
-  }
+  // // Generate ETag with request-sensitive context (Accept variant + optional query params)
+  // const etagContext = buildEtagContext(res.req, queryParams);
+  // const etag = generateEtagWithParams(metadata.etag, etagContext);
+
+  // if (etag) {
+  //   res.setHeader('ETag', etag);
+  // }
+
+  // if (metadata.lastModified) {
+  //   res.setHeader('Last-Modified', metadata.lastModified);
+  // }
+
+  // // Set Cache-Control header
+  // // - public: can be cached by browsers and CDNs
+  // // - max-age: how long the cache is fresh
+  // // - must-revalidate: must check with server after max-age expires
+  // res.setHeader('Cache-Control', `public, max-age=${maxAge}, must-revalidate`);
+
+  // // Ensure Vary: Accept is present so caches know the response varies by Accept header
+  // const existingVary = res.getHeader('Vary');
+  // if (existingVary === undefined) {
+  //   res.setHeader('Vary', 'Accept');
+  // } else {
+  //   const headerValue = Array.isArray(existingVary)
+  //     ? existingVary.join(',')
+  //     : String(existingVary);
+  //   const varySet = new Set<string>();
+  //   headerValue.split(',').forEach(value => {
+  //     const trimmed = value.trim();
+  //     if (trimmed) {
+  //       varySet.add(trimmed);
+  //     }
+  //   });
+  //   let hasAccept = false;
+  //   for (const v of varySet) {
+  //     if (v.toLowerCase() === 'accept') {
+  //       hasAccept = true;
+  //       break;
+  //     }
+  //   }
+  //   if (!hasAccept) {
+  //     varySet.add('Accept');
+  //   }
+  //   res.setHeader('Vary', Array.from(varySet).join(', '));
+  // }
 }
 
 /**
@@ -229,11 +231,11 @@ export function sendNotModified(
   // Generate ETag with request-sensitive context (Accept variant + optional query params)
   const etagContext = buildEtagContext(res.req, queryParams);
   const etag = generateEtagWithParams(metadata.etag, etagContext);
-    
+
   if (etag) {
     res.setHeader('ETag', etag);
   }
-  
+
   if (metadata.lastModified) {
     res.setHeader('Last-Modified', metadata.lastModified);
   }
@@ -270,6 +272,6 @@ export function sendNotModified(
   if (!res.getHeader('Cache-Control')) {
     res.setHeader('Cache-Control', `public, max-age=${maxAge}, must-revalidate`);
   }
-  
+
   res.status(304).end();
 }


### PR DESCRIPTION
Disable ETag generation and caching temporarily to iterate on ETag logic and monitor cache behavior in production. Re-enabling will occur once the implementation is confident.