### PR TITLE
Add Redis 8.8 to registry

### DIFF
--- a/resources/image/registry.json
+++ b/resources/image/registry.json
@@ -9124,6 +9124,47 @@
       "repo_name": "redis"
     },
     "versions": {
+      "8.8": {
+        "upsun": {
+          "status": "supported",
+          "internal_support": true,
+          "internal_status": "active"
+        },
+        "upstream": {
+          "status": "supported",
+          "releaseDate": "2026-05-25T00:00:00.000Z",
+          "eoasFrom": null,
+          "eolFrom": null,
+          "isLts": false,
+          "isMaintained": true,
+          "isEoas": false,
+          "isEol": false
+        },
+        "manifest": {
+          "endpoints": {
+            "redis": {
+              "port": 6379,
+              "schema": "redis",
+              "scheme": "redis",
+              "default": true
+            }
+          },
+          "min_cpu_size": 0.1,
+          "min_mem_size": 64,
+          "is_persistent": null,
+          "min_disk_size": null,
+          "allow_scale_up": true,
+          "package_version": {
+            "raw": "8.8.0-0psh2",
+            "majorMinor": "8.8",
+            "normalized": "8.8.0"
+          },
+          "allow_scale_down": true,
+          "storage_mount_point": null,
+          "default_container_profile": "BALANCED",
+          "supports_horizontal_scaling": false
+        }
+      },
       "8.0": {
         "upsun": {
           "status": "supported",


### PR DESCRIPTION
## Summary
- Add Redis 8.8 as supported version in `registry.json`

## Test plan
- [x] Verify registry.json is valid JSON
- [ ] Verify Redis 8.8 appears in docs after deploy